### PR TITLE
new DataSet.compute_multiplicity method

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -585,7 +585,7 @@ class DataSet(pd.DataFrame):
             dataset = self.copy()
 
         epsilon = compute_structurefactor_multiplicity(self.get_hkls(), self.spacegroup, include_centering)
-        dataset['EPSILON'] = rs.DataSeries(epsilon, dtype='R', index=dataset.index)
+        dataset['EPSILON'] = rs.DataSeries(epsilon, dtype='I', index=dataset.index)
         return dataset
 
     def assign_resolution_bins(self, bins=20, inplace=False, return_labels=True):

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -13,6 +13,7 @@ from reciprocalspaceship.utils import (
     hkl_to_asu,
     hkl_to_observed,
     compute_dHKL,
+    compute_structurefactor_multiplicity,
 )
 
 class DataSet(pd.DataFrame):
@@ -563,6 +564,28 @@ class DataSet(pd.DataFrame):
 
         dHKL = compute_dHKL(self.get_hkls(), self.cell)
         dataset['dHKL'] = rs.DataSeries(dHKL, dtype='R', index=dataset.index)
+        return dataset
+
+    def compute_multiplicity(self, inplace=False, include_centering=True):
+        """
+        Compute the multiplicity of reflections in DataSet. A new column of
+        floats, "EPSILON", is added to the object.
+
+        Parameters
+        ----------
+        inplace : bool
+            Whether to add the column in place or to return a copy
+        include_centering : bool
+            Whether to include centering operations in the multiplicity calculation.
+            The default is to include them.
+        """
+        if inplace:
+            dataset = self
+        else:
+            dataset = self.copy()
+
+        epsilon = compute_structurefactor_multiplicity(self.get_hkls(), self.spacegroup, include_centering)
+        dataset['EPSILON'] = rs.DataSeries(epsilon, dtype='R', index=dataset.index)
         return dataset
 
     def assign_resolution_bins(self, bins=20, inplace=False, return_labels=True):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -218,7 +218,7 @@ def test_compute_dHKL(dataset_hkl, inplace, cell):
     gemmi.SpaceGroup(4),
 ])
 def test_compute_multiplicity(dataset_hkl, inplace, include_centering, spacegroup):
-    """Test DataSet.compute_dHKL()"""
+    """Test DataSet.compute_multiplicity()"""
     dataset_hkl.spacegroup = spacegroup 
     result = dataset_hkl.compute_multiplicity(inplace=inplace, include_centering=include_centering)
 
@@ -229,7 +229,7 @@ def test_compute_multiplicity(dataset_hkl, inplace, include_centering, spacegrou
         assert id(result) != id(dataset_hkl)
 
     # Compare to gemmi result
-    expected = np.zeros(len(result), dtype=np.float32)
+    expected = np.zeros(len(result), dtype=np.int32)
     ops = spacegroup.operations()
     if include_centering:
         for i, h in enumerate(result.get_hkls()):
@@ -238,8 +238,8 @@ def test_compute_multiplicity(dataset_hkl, inplace, include_centering, spacegrou
         for i, h in enumerate(result.get_hkls()):
             expected[i] = ops.epsilon_factor_without_centering(h)
 
-    assert np.allclose(result["EPSILON"].to_numpy(), expected)
-    assert isinstance(result["EPSILON"].dtype, rs.MTZRealDtype)
+    assert np.all(result["EPSILON"].to_numpy() == expected)
+    assert isinstance(result["EPSILON"].dtype, rs.MTZIntDtype)
 
 
 @pytest.mark.parametrize("bins", [5, 10, 20, 50])


### PR DESCRIPTION
I was tired of dipping into `rs.utils` to compute multiplicities, so I made an `rs.DataSet.compute_multiplicity` method. This computes the multiplicity and adds a new `"EPSILON"` column to the data set. 