### PR TITLE
MTZIntegerArray.to_numpy() should default to np.int32 where possible

### DIFF
--- a/reciprocalspaceship/dtypes/base.py
+++ b/reciprocalspaceship/dtypes/base.py
@@ -65,7 +65,7 @@ class MTZIntegerArray(IntegerArray):
 
         If array does not contain any NaN values, will return a np.int32
         ndarray. If array contains NaN values, will return a ndarray of 
-        np.float32 dtype.
+        object dtype.
 
         Parameters
         ----------
@@ -88,6 +88,7 @@ class MTZIntegerArray(IntegerArray):
         """
         if na_value is lib.no_default:
             na_value = libmissing.NA
+
         if dtype is None:
             if self._hasna:
                 dtype = object
@@ -99,6 +100,7 @@ class MTZIntegerArray(IntegerArray):
             data[self._mask] = na_value
         else:
             data = self._data.astype(dtype, copy=copy)
+
         return data
 
     def value_counts(self, dropna=True):

--- a/tests/dtypes/test_dtypes.py
+++ b/tests/dtypes/test_dtypes.py
@@ -37,3 +37,15 @@ def test_astype_name(dtype_all):
     result = expected.astype(expected.dtype.name)
     assert_series_equal(result, expected)
     assert expected.dtype.name == str(result.dtype)
+
+@pytest.mark.parametrize("with_nan", [True,  False])
+def test_to_numpy_nan(data_int, with_nan):
+    """Test int32-backed ExtensionArray to_numpy() method"""
+    if with_nan:
+        data_int[10] = data_int._na_value
+
+    result = data_int.to_numpy()
+    if with_nan:
+        assert result.dtype.name == "object"
+    else:
+        assert result.dtype.name == "int32"


### PR DESCRIPTION
The default behavior for a pandas `IntegerArray.to_numpy()` method is to return a numpy array of type `object`. This ensures support for NaN-values that can be represented in the `IntegerArray`, but not in a numpy array of `np.int32`. 

In order to minimize any surprise that may be caused by this default behavior, this PR changes the default behavior of `MTZIntegerArray.to_numpy()` to be to return a `np.int32` array if there are no NaN values in the array, but to keep the `object` return type if NaNs are present. This seems like a good compromise to maintain pandas-like behavior while improving default numpy conversions in many common cases. 