### PR TITLE
Add DataSet.to_reciprocalgrid() for arranging data on 3D grid by Miller index

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1069,11 +1069,9 @@ class DataSet(pd.DataFrame):
         groupops = self.spacegroup.operations()
         p1 = rs.concat([ self.apply_symop(op) for op in groupops ])
         p1.spacegroup = gemmi.SpaceGroup(1)
-        # p1.hkl_to_asu(inplace=True)
         p1.reset_index(inplace=True)
         p1.drop_duplicates(subset=["H", "K", "L"], inplace=True)
         p1.set_index(["H", "K", "L"], inplace=True)
-        # p1.drop(columns="M/ISYM", inplace=True)
         return p1
 
     def expand_anomalous(self):

--- a/tests/test_dataset_grid.py
+++ b/tests/test_dataset_grid.py
@@ -19,10 +19,11 @@ def test_to_reciprocalgrid_complex(mtz_by_spacegroup, sample_rate, p1):
     testp1 = dataset.expand_to_p1()
     testp1.spacegroup = dataset.spacegroup
     gridsize = testp1.to_gemmi().get_size_for_hkl(sample_rate=sample_rate)
+
     gemmigrid = gemmimtz.get_f_phi_on_grid("FMODEL", "PHIFMODEL", size=gridsize)
     expected = np.array(gemmigrid)
-    testp1["sf"] = testp1.to_structurefactor("FMODEL", "PHIFMODEL")
-    result = testp1.to_reciprocalgrid("sf", gridsize)
+    dataset["sf"] = dataset.to_structurefactor("FMODEL", "PHIFMODEL")
+    result = dataset.to_reciprocalgrid("sf", gridsize)
     assert np.allclose(result, expected, rtol=1e-4)
 
 @pytest.mark.parametrize("sample_rate", [1, 2, 3])

--- a/tests/test_dataset_grid.py
+++ b/tests/test_dataset_grid.py
@@ -1,0 +1,36 @@
+import pytest
+import numpy as np
+import gemmi
+import reciprocalspaceship as rs
+
+@pytest.mark.parametrize("sample_rate", [1, 2, 3])
+def test_to_reciprocalgrid_p1complex(mtz_by_spacegroup, sample_rate):
+    """
+    Test DataSet.to_reciprocalgrid() against gemmi for complex P1 data
+    """
+    dataset = rs.read_mtz(mtz_by_spacegroup[:-4] + "_p1.mtz")
+    gemmimtz = dataset.to_gemmi()
+    gridsize = gemmimtz.get_size_for_hkl(sample_rate=sample_rate)
+    gemmigrid = gemmimtz.get_f_phi_on_grid("FMODEL", "PHIFMODEL", size=gridsize)
+    expected = np.array(gemmigrid)
+    dataset["sf"] = dataset.to_structurefactor("FMODEL", "PHIFMODEL")
+    result = dataset.to_reciprocalgrid("sf", gridsize)
+    assert np.allclose(result, expected)
+
+@pytest.mark.parametrize("sample_rate", [1, 2, 3])
+@pytest.mark.parametrize("p1", [True, False])
+def test_to_reciprocalgrid(mtz_by_spacegroup, sample_rate, p1):
+    """
+    Test DataSet.to_reciprocalgrid() against gemmi for float data
+    """
+    if p1:
+        dataset = rs.read_mtz(mtz_by_spacegroup[:-4] + "_p1.mtz")
+    else:
+        dataset = rs.read_mtz(mtz_by_spacegroup)
+    gemmimtz = dataset.to_gemmi()
+    gridsize = dataset.expand_to_p1().to_gemmi().get_size_for_hkl(sample_rate=sample_rate)
+    gemmigrid = gemmimtz.get_value_on_grid("FMODEL", size=gridsize)
+    expected = np.array(gemmigrid)
+    result = dataset.to_reciprocalgrid("FMODEL", gridsize)
+    assert np.allclose(result, expected)
+


### PR DESCRIPTION
This method is meant to go between the "tabular" view of the data provided by the `DataSet` class and the 3D grid that it represents (values indexed by HKL values). 