### PR TITLE
Rename private attribute _cache_index_dtypes

### DIFF
--- a/reciprocalspaceship/concat.py
+++ b/reciprocalspaceship/concat.py
@@ -37,11 +37,11 @@ def concat(*args, check_isomorphous=True, **kwargs):
         
     result = pd.concat(*args, **kwargs)
 
-    # If `ignore_index=True`, the _cache_index_dtypes attribute should
+    # If `ignore_index=True`, the _index_dtypes_cache attribute should
     # be reset.
-    if isinstance(result.index, pd.RangeIndex) and first._cache_index_dtypes != {}:
+    if isinstance(result.index, pd.RangeIndex) and first._index_dtypes_cache != {}:
         result.__finalize__(first)
-        result._cache_index_dtypes = {}
+        result._index_dtypes_cache = {}
         return result
     
     return result.__finalize__(first)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -140,7 +140,7 @@ def test_from_gemmi(data_gemmi):
     assert_frame_equal(result, expected)
     assert result.spacegroup == expected.spacegroup
     assert result.cell == expected.cell
-    assert result._cache_index_dtypes == expected._cache_index_dtypes
+    assert result._index_dtypes_cache == expected._index_dtypes_cache
         
 
 def test_get_phase_keys(data_fmodel):

--- a/tests/test_dataset_index.py
+++ b/tests/test_dataset_index.py
@@ -29,7 +29,7 @@ def test_reset_index(data_fmodel, level, drop, inplace):
                 assert c not in data_fmodel.columns
             else:
                 assert c in data_fmodel.columns
-        assert cache == list(data_fmodel._cache_index_dtypes.keys())
+        assert cache == list(data_fmodel._index_dtypes_cache.keys())
         
     else:
         assert id(result) != id(data_fmodel)
@@ -42,5 +42,5 @@ def test_reset_index(data_fmodel, level, drop, inplace):
             else:
                 assert c in result.columns
                 assert c not in data_fmodel.columns
-        assert cache == list(result._cache_index_dtypes.keys())
-        assert cache != list(data_fmodel._cache_index_dtypes.keys())
+        assert cache == list(result._index_dtypes_cache.keys())
+        assert cache != list(data_fmodel._index_dtypes_cache.keys())

--- a/tests/test_dataset_preserve_attributes.py
+++ b/tests/test_dataset_preserve_attributes.py
@@ -22,9 +22,9 @@ def test_concat(data_fmodel, check_isomorphous, sg, ignore_index):
         assert isinstance(result, rs.DataSet)
         assert len(result) == len(data_fmodel)*2
         if ignore_index:
-            assert result._cache_index_dtypes == {}
+            assert result._index_dtypes_cache == {}
         for attr in data_fmodel._metadata:
-            if attr ==  "_cache_index_dtypes":
+            if attr ==  "_index_dtypes_cache":
                 continue
             assert result.__getattr__(attr) == data_fmodel.__getattr__(attr)
 
@@ -46,9 +46,9 @@ def test_append(data_fmodel, check_isomorphous, sg, ignore_index):
         assert isinstance(result, rs.DataSet)
         assert len(result) == len(data_fmodel)*2
         if ignore_index:
-            assert result._cache_index_dtypes == {}
+            assert result._index_dtypes_cache == {}
         for attr in data_fmodel._metadata:
-            if attr ==  "_cache_index_dtypes":
+            if attr ==  "_index_dtypes_cache":
                 continue
             assert result.__getattr__(attr) == data_fmodel.__getattr__(attr)
 
@@ -72,9 +72,9 @@ def test_append_list(data_fmodel, check_isomorphous, sg, ignore_index):
         assert isinstance(result, rs.DataSet)
         assert len(result) == len(data_fmodel)*4
         if ignore_index:
-            assert result._cache_index_dtypes == {}
+            assert result._index_dtypes_cache == {}
         for attr in data_fmodel._metadata:
-            if attr ==  "_cache_index_dtypes":
+            if attr ==  "_index_dtypes_cache":
                 continue
             assert result.__getattr__(attr) == data_fmodel.__getattr__(attr)
 


### PR DESCRIPTION
This PR changes the private attribute `DataSet._cache_index_dtypes` to `DataSet._index_dtypes_cache` to ensure consistent naming for attributes vs methods.