### PR TITLE
Handle centric reflections and unmerged data in stack_anomalous() and unstack_anomalous()

### DIFF
--- a/tests/test_dataset_anomalous.py
+++ b/tests/test_dataset_anomalous.py
@@ -12,15 +12,12 @@ from reciprocalspaceship.utils import in_asu
     (["I(+)", "SIGI(+)"], ["I(-)"]),
     (["I(+)", "SIGI(+)"], ["SIGI(-)", "I(-)"]),    
 ])
-def test_stack_anomalous(data_hewl, labels):
+def test_stack_anomalous(data_merged, labels):
     """Test behavior of DataSet.stack_anomalous()"""
 
     plus_labels = labels[0]
     minus_labels = labels[1]
     
-    if not data_hewl.merged:
-        data_hewl = data_hewl.unstack_anomalous(["I", "SIGI"])
-
     # Check input data
     def check_ValueError(data, plus_labels, minus_labels):
         with pytest.raises(ValueError):
@@ -28,8 +25,8 @@ def test_stack_anomalous(data_hewl, labels):
         return
 
     if (plus_labels is None and minus_labels is None):
-        plus_labels  = [ l for l in data_hewl.columns if "(+)" in l ]
-        minus_labels = [ l for l in data_hewl.columns if "(-)" in l ]
+        plus_labels  = [ l for l in data_merged.columns if "(+)" in l ]
+        minus_labels = [ l for l in data_merged.columns if "(-)" in l ]
 
     if isinstance(plus_labels, str) and isinstance(minus_labels, str):
         plus_labels = [plus_labels]
@@ -37,19 +34,31 @@ def test_stack_anomalous(data_hewl, labels):
     elif (isinstance(plus_labels, list) and
           isinstance(minus_labels, list)):
         if len(plus_labels) != len(minus_labels):
-            check_ValueError(data_hewl, plus_labels, minus_labels)
+            check_ValueError(data_merged, plus_labels, minus_labels)
             return
     else:
-        check_ValueError(data_hewl, plus_labels, minus_labels)
+        check_ValueError(data_merged, plus_labels, minus_labels)
         return
 
     for plus, minus in zip(plus_labels, minus_labels):
-        if data_hewl[plus].dtype != data_hewl[minus].dtype:
-            check_ValueError(data_hewl, plus_labels, minus_labels)
+        if data_merged[plus].dtype != data_merged[minus].dtype:
+            check_ValueError(data_merged, plus_labels, minus_labels)
             return
 
-    result = data_hewl.stack_anomalous(plus_labels, minus_labels)
-    assert len(result.columns) == (len(data_hewl.columns)-len(plus_labels))
+    result = data_merged.stack_anomalous(plus_labels, minus_labels)
+    centrics = data_merged.label_centrics()["CENTRIC"]
+    assert len(result.columns) == (len(data_merged.columns)-len(plus_labels))
+    assert len(result) == (2*(~centrics).sum()) + centrics.sum()
+    assert result.spacegroup.xhm() == data_merged.spacegroup.xhm()
+    
+
+def test_stack_anomalous_unmerged(data_unmerged):
+    """
+    Test DataSet.stack_anomalous() raises ValueError with unmerged data
+    """
+    with pytest.raises(ValueError):
+        result = data_unmerged.stack_anomalous()
+
 
 @pytest.mark.parametrize("columns", [
     None,
@@ -63,12 +72,12 @@ def test_stack_anomalous(data_hewl, labels):
     ("(+)"),
     ("(+)", "(-)")
 ])
-def test_unstack_anomalous(data_hewl, columns, suffixes):
+def test_unstack_anomalous(data_merged, columns, suffixes):
     """Test behavior of DataSet.unstack_anomalous()"""
 
-    if data_hewl.merged:
-        data_hewl = data_hewl.stack_anomalous()
-    
+    data_merged = data_merged.stack_anomalous()
+
+        
     def check_ValueError(data, columns, suffixes):
         with pytest.raises(ValueError):
             result = data.unstack_anomalous(columns, suffixes)
@@ -76,60 +85,48 @@ def test_unstack_anomalous(data_hewl, columns, suffixes):
     
     # Test input validation
     if columns is None:
-        columns = data_hewl.columns.to_list()
+        columns = data_merged.columns.to_list()
     elif isinstance(columns, str):
         columns = [columns]
     elif not isinstance(columns, (list, tuple)):
-        check_ValueError(data_hewl, columns, suffixes)
+        check_ValueError(data_merged, columns, suffixes)
         return
     if not (isinstance(suffixes, (list, tuple)) and len(suffixes) == 2):
-        check_ValueError(data_hewl, columns, suffixes)
+        check_ValueError(data_merged, columns, suffixes)
         return
 
-    result = data_hewl.unstack_anomalous(columns, suffixes)
-    assert len(result.columns) == (len(data_hewl.columns)+len(columns))
+    result = data_merged.unstack_anomalous(columns, suffixes)
+    centrics = data_merged.label_centrics()["CENTRIC"]
+    assert len(result.columns) == (len(data_merged.columns)+len(columns))
     assert in_asu(result.get_hkls(), result.spacegroup).all()
-    
-    # Check expected behavior with merged DataSet
-    if data_hewl.merged:
-        assert len(result) == len(data_hewl)/2
+    assert len(result) == ((~centrics).sum()/2) + centrics.sum()
+    assert result.spacegroup.xhm() == data_merged.spacegroup.xhm()
 
-    # Check expected behavior with unmerged DataSet
-    else:
-        assert len(result) == len(data_hewl)
         
-def test_roundtrip_merged(data_merged):
+def test_unstack_anomalous_unmerged(data_unmerged):
+    """
+    Test DataSet.unstack_anomalous() raises ValueError with unmerged data
+    """
+    with pytest.raises(ValueError):
+        result = data_unmerged.unstack_anomalous()
+
+
+@pytest.mark.parametrize("rangeindexed", [True, False])
+def test_roundtrip_merged(data_merged, rangeindexed):
     """
     Test that DataSet is unchanged by roundtrip call of DataSet.stack_anomalous()
     followed by DataSet.unstack_anomalous()
     """
-    stacked = data_merged.stack_anomalous()
+    if rangeindexed:
+        data = data_merged.reset_index()
+    else:
+        data = data_merged
+        
+    stacked = data.stack_anomalous()
     result = stacked.unstack_anomalous(["I", "SIGI", "N"])
 
     # Re-order columns if needed
-    result = result[data_merged.columns]
+    result = result[data.columns]
 
-    assert_frame_equal(result, data_merged)
-
-
-def test_roundtrip_unmerged(data_unmerged):
-    """
-    Test that DataSet is unchanged by roundtrip call of DataSet.unstack_anomalous()
-    followed by DataSet.stack_anomalous()
-    """
-    unstacked = data_unmerged.unstack_anomalous(["I", "SIGI"])
-    result = unstacked.stack_anomalous()
-
-    # Re-order columns if needed
-    result = result[data_unmerged.columns]
-    result.reset_index(inplace=True)
-    result.set_index(["H", "K", "L", "BATCH"], inplace=True)
-    data_unmerged.set_index(["BATCH"], append=True, inplace=True)
-    
-    # Sort indices for comparison
-    result.sort_index(inplace=True)
-    data_unmerged.sort_index(inplace=True)
-
-    assert_frame_equal(result, data_unmerged)
-
-
+    # DataSet.merge() operations seem to recast index dtypes
+    assert_frame_equal(result, data, check_index_type=False)


### PR DESCRIPTION
Fixes #26 and #27.

This PR fixes the handling of centric reflections in `DataSet.stack_anomalous()` and `DataSet.unstack_anomalous()`. After this PR, centric reflections will no longer be mapped to the Friedel-minus ASU by these reshaping operations.

In addition, a `ValueError` will now be raised when `stack_anomalous()` or. `unstack_anomalous()` are invoked on an unmerged DataSet.