### PR TITLE
Fix handling of centrics in DataSet.hkl_to_asu(anomalous=True)

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -958,8 +958,8 @@ class DataSet(pd.DataFrame):
         inplace : bool
             Whether to modify the DataSet in place or return a copy
         anomalous : bool
-            If True, reflections will be mapped to the +/- ASU. If False,
-            reflections are only mapped to the Friedel-plus ASU. 
+            If True, acentric reflections will be mapped to the +/- ASU. 
+            If False, all reflections are mapped to the Friedel-plus ASU. 
 
         Returns
         -------

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -997,9 +997,11 @@ class DataSet(pd.DataFrame):
             dataset['M/ISYM'] = DataSeries(isym[inverse], dtype="M/ISYM", index=dataset.index)
 
         # GH#16: Handle anomalous flag to separate Friedel pairs
+        # GH#25: Centrics should not be considered Friedel pairs
         if anomalous:
+            acentric = ~dataset.label_centrics()["CENTRIC"]
             friedel_minus = dataset['M/ISYM']%2 == 0
-            dataset[friedel_minus] = dataset[friedel_minus].apply_symop("-x,-y,-z")
+            dataset[friedel_minus & acentric] = dataset[friedel_minus & acentric].apply_symop("-x,-y,-z")
             
         return dataset
 

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -20,25 +20,35 @@ def test_hkl_to_asu(mtz_by_spacegroup, inplace, reset_index, anomalous):
     if reset_index:
         yasu.set_index(['H', 'K', 'L'], inplace=True)
 
+    # Confirm centric reflections are always in +ASU
+    expected_centric = x.loc[x.label_centrics()["CENTRIC"]]
+    result_centric   = yasu.loc[yasu.label_centrics()["CENTRIC"]]
+    assert len(expected_centric.index.difference(result_centric.index)) == 0
+    assert len(result_centric.index.difference(expected_centric.index)) == 0    
+
+    # If anomalous=True, confirm acentric reflections were in +/- ASU
     if anomalous:
         yasu.reset_index(inplace=True)
+        acentric = ~yasu.label_centrics()["CENTRIC"]
         friedel_minus = yasu['M/ISYM']%2 == 0
-        yasu[friedel_minus] = yasu[friedel_minus].apply_symop("-x,-y,-z")
+        yasu[friedel_minus & acentric] = yasu[friedel_minus & acentric].apply_symop("-x,-y,-z")
         yasu.set_index(['H', 'K', 'L'], inplace=True)
-        
-    assert len(x.index.difference(yasu.index)) == 0
     assert len(yasu.index.difference(x.index)) == 0
+    assert len(x.index.difference(yasu.index)) == 0
 
+    # Confirm structure factor amplitudes are always unchanged
     Fx    = x.loc[yasu.index, 'FMODEL'].values.astype(float) 
     Fyasu = yasu['FMODEL'].values.astype(float) 
     assert np.allclose(Fx, Fyasu)
 
+    # Confirm phase changes are applied
     Phx    = x.loc[yasu.index, 'PHIFMODEL'].values.astype(float) 
     Phyasu = yasu['PHIFMODEL'].values.astype(float) 
     Sx    = Fx*np.exp(1j*np.deg2rad(Phx))
     Syasu = Fyasu*np.exp(1j*np.deg2rad(Phyasu))
     assert np.allclose(Sx, Syasu, rtol=1e-3)
 
+    # Confirm inplace
     if inplace:
         assert id(yasu) == id(y)
     else:


### PR DESCRIPTION
Improves handling of centrics in `DataSet.hkl_to_asu(anomalous=True)`. Previously, the `anomalous=True` flag would lead to the remapping of centric reflections to the +/- reciprocal space ASU depending on the observed Miller index. However, it does not make sense to split centric reflections in this manner because they are not valid Friedel pairs. 

This PR fixes the handling of centrics such that they are unchanged by the `anomalous` flag. In all cases, `DataSet.hkl_to_asu()` will map centric reflections to the +ASU. 
