### PR TITLE
Add function for writing CCP4 maps from NumPy arrays

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -30,7 +30,7 @@ These two objects can be thought of as crystallographically-aware versions of ``
 Input/Output
 ------------
 
-Supported crystallographic file formats for data I/O. Write functions are available as methods of ``rs.DataSet`` objects.
+Supported crystallographic file formats for data I/O. Write functions for reflection file formats are available as methods of ``rs.DataSet`` objects.
 
 .. currentmodule:: reciprocalspaceship
 .. autosummary::
@@ -39,6 +39,7 @@ Supported crystallographic file formats for data I/O. Write functions are availa
 
    ~reciprocalspaceship.read_mtz
    ~reciprocalspaceship.read_precognition
+   ~reciprocalspaceship.io.write_ccp4_map
 
 Algorithms
 ----------

--- a/reciprocalspaceship/io/__init__.py
+++ b/reciprocalspaceship/io/__init__.py
@@ -7,3 +7,4 @@ from .mtz import (
 from .precognition import (
     read_precognition,
 )
+from .ccp4map import write_ccp4_map

--- a/reciprocalspaceship/io/ccp4map.py
+++ b/reciprocalspaceship/io/ccp4map.py
@@ -30,6 +30,6 @@ def write_ccp4_map(realmap, mapfile, cell, spacegroup):
     ccp4 = gemmi.Ccp4Map()
     ccp4.grid = grid
     ccp4.update_ccp4_header(2, True)
-    ccp4.write_ccp4_map(mapout)
+    ccp4.write_ccp4_map(mapfile)
     
     return

--- a/reciprocalspaceship/io/ccp4map.py
+++ b/reciprocalspaceship/io/ccp4map.py
@@ -1,0 +1,35 @@
+import numpy as np
+import gemmi
+
+def write_ccp4_map(realmap, mapfile, cell, spacegroup):
+    """
+    Write CCP4 map file from NumPy array of real-space density.
+
+    Parameters
+    ----------
+    realmap : np.ndarray
+        3D NumPy array of real-space, voxelized electron density
+    mapfile :  str
+        Filename to which map will be written
+    cell : gemmi.UnitCell
+        Unit cell parameters to use in map file
+    spacegroup : gemmi.SpaceGroup
+        Spacegroup to use in map file
+    """
+    if not isinstance(realmap, np.ndarray) or not (realmap.ndim == 3):
+        raise ValueError("realmap must be a 3-dimension NumPy array")
+
+    # Set up gemmi FloatGrid object with NumPy array
+    grid = gemmi.FloatGrid(*realmap.shape)
+    grid.set_unit_cell(cell)
+    grid.spacegroup = spacegroup
+    temp = np.array(grid, copy=False)
+    temp[:, :, :] = realmap[:, :, :]
+
+    # Write CCP4 map
+    ccp4 = gemmi.Ccp4Map()
+    ccp4.grid = grid
+    ccp4.update_ccp4_header(2, True)
+    ccp4.write_ccp4_map(mapout)
+    
+    return

--- a/tests/io/test_ccp4map.py
+++ b/tests/io/test_ccp4map.py
@@ -1,0 +1,39 @@
+import pytest
+import tempfile
+from os.path import exists
+import numpy as np
+import gemmi
+import reciprocalspaceship as rs
+
+
+@pytest.mark.parametrize("realmap", [
+    np.zeros((10, 20, 30)),
+    np.random.rand(10, 20, 30),
+    np.zeros((10, 20)),
+    np.zeros((10, 20, 30)).tolist()
+])
+def test_write_ccp4_map(realmap):
+    """Test rs.io.write_ccp4_map()"""
+    mapfile = tempfile.NamedTemporaryFile(suffix=".map")
+    sg = gemmi.SpaceGroup(1)
+    cell = gemmi.UnitCell(10., 20., 30., 90., 90., 90.)
+
+    if not isinstance(realmap, np.ndarray) or not (realmap.ndim == 3):
+        with pytest.raises(ValueError):
+            rs.io.write_ccp4_map(realmap, mapfile.name, cell, sg)
+        mapfile.close()
+        return
+
+    rs.io.write_ccp4_map(realmap, mapfile.name, cell, sg)
+    assert exists(mapfile.name)
+    mapfile.close()
+    
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR adds a function, `rs.io.write_ccp4_map()`, which uses `gemmi` to write a CCP4-format map file from a 3D NumPy array.  This allows one to write map files for real-space density that can be viewed in typical molecular graphics programs (PyMOL, COOT, etc).