### PR TITLE
Add rs.read_csv() to construct DataSet from CSV file

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -38,6 +38,7 @@ Supported crystallographic file formats for data I/O. Write functions for reflec
    :nosignatures:
 
    ~reciprocalspaceship.read_mtz
+   ~reciprocalspaceship.read_csv
    ~reciprocalspaceship.read_precognition
    ~reciprocalspaceship.io.write_ccp4_map
 

--- a/reciprocalspaceship/__init__.py
+++ b/reciprocalspaceship/__init__.py
@@ -8,7 +8,7 @@ __version__ = getVersionNumber()
 # Top-Level API
 from .dataset import DataSet
 from .dataseries import DataSeries
-from .io import read_mtz, read_precognition
+from .io import read_mtz, read_precognition, read_csv
 from .dtypes import summarize_mtz_dtypes
 from .concat import concat
 

--- a/reciprocalspaceship/io/__init__.py
+++ b/reciprocalspaceship/io/__init__.py
@@ -8,3 +8,4 @@ from .precognition import (
     read_precognition,
 )
 from .ccp4map import write_ccp4_map
+from .csv import read_csv

--- a/reciprocalspaceship/io/csv.py
+++ b/reciprocalspaceship/io/csv.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from reciprocalspaceship import DataSet
+
+def read_csv(csvfile, spacegroup=None, cell=None, merged=None,
+             infer_mtz_dtypes=True, *args, **kwargs):
+    """
+    Read a comma-separated values (csv) file into a DataSet.
+
+    This method also supports the arguments to `pandas.read_csv <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html>`_. See their documentation
+    for more details.
+
+    Parameters
+    ----------
+    csvfile : str, path object, or file-like object
+        File to read as CSV file
+    spacegroup : gemmi.SpaceGroup, int, or str
+        Spacegroup with which to initialize DataSet
+    cell : gemmi.UnitCell, tuple, list, or array-like
+        Cell parameters with which to initialize DataSet
+    merged : bool
+        Whether DataSet contains merged reflection data
+    infer_mtz_dtypes : bool
+        Whether to infer MTZ dtypes based on column names
+
+    Returns
+    -------
+    rs.DataSet
+    """
+    df = pd.read_csv(csvfile, *args, **kwargs)
+    ds = DataSet(df, spacegroup=spacegroup, cell=cell, merged=merged)
+    if infer_mtz_dtypes:
+        ds.infer_mtz_dtypes(inplace=True)
+    return ds

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -1,0 +1,48 @@
+import pytest
+import tempfile
+import reciprocalspaceship as rs
+import gemmi
+from pandas.testing import assert_frame_equal
+
+@pytest.mark.parametrize("sep", [",", "\t", ";"])
+@pytest.mark.parametrize("spacegroup", [None, gemmi.SpaceGroup("P 1"), 1, "P 1"])
+@pytest.mark.parametrize("cell", [
+    None,
+    gemmi.UnitCell(1, 1, 1, 90, 90, 90),
+    (1, 1, 1, 90, 90, 90)
+])
+@pytest.mark.parametrize("merged", [None, True, False])
+@pytest.mark.parametrize("infer_mtz_dtypes", [True, False])
+def test_read_csv(IOtest_mtz, sep, spacegroup, cell, merged, infer_mtz_dtypes):
+    """Test rs.read_csv()"""
+    csvfile = tempfile.NamedTemporaryFile(suffix=".csv")
+    expected = rs.read_mtz(IOtest_mtz)
+    expected.to_csv(csvfile.name, sep=sep)
+    result = rs.read_csv(csvfile.name, spacegroup=spacegroup, cell=cell,
+                         merged=merged, infer_mtz_dtypes=infer_mtz_dtypes, sep=sep)
+    print(result)
+    result.set_index(["H", "K", "L"], inplace=True)
+    csvfile.close()
+
+    if spacegroup:
+        if isinstance(spacegroup, gemmi.SpaceGroup):
+            assert result.spacegroup.xhm() == spacegroup.xhm()
+        else:
+            assert result.spacegroup.xhm() == gemmi.SpaceGroup(spacegroup).xhm()
+    else:
+        assert result.spacegroup is None
+
+    if cell:
+        if isinstance(cell, gemmi.UnitCell):
+            assert result.cell.a == cell.a
+        else:
+            assert result.cell.a == cell[0]
+    else:
+        assert result.cell is None
+
+    assert result.merged == merged
+    
+    if infer_mtz_dtypes:
+        assert_frame_equal(result, expected)
+    else:
+        assert_frame_equal(result, expected, check_dtype=False, check_index_type=False)


### PR DESCRIPTION
This PR adds `rs.read_csv()` to construct a `DataSet` from a CSV file. This method takes additional parameters that are passed to the `rs.DataSet()` constructor (`spacegroup`, `cell`,  `merged`), and also accepts a boolean `infer_mtz_dtypes` to determine whether MTZ dtypes will be inferred for the data.

Internally, this method calls `pd.read_csv()`, and any additional keyword arguments accepted by the `pandas` function can also be passed to `rs.read_csv()`.