### PR TITLE
Update to support Pandas 1.2.0

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -84,17 +84,21 @@ class DataSet(pd.DataFrame):
         self._spacegroup = None
         self._cell = None
         self._merged = None
-        
-        if isinstance(data, DataSet):
-            self.__finalize__(data)
 
-        elif isinstance(data, gemmi.Mtz):
+        # Construct DataSet from gemmi.Mtz object
+        if isinstance(data, gemmi.Mtz):
             from reciprocalspaceship import io
             dataset = io.from_gemmi(data)
-            self.__finalize__(dataset)
             data = dataset
 
-        # Provided values for DataSet attributes take precedence
+        super().__init__(data=data, index=index, columns=columns,
+                         dtype=dtype, copy=copy)
+
+        # Copy over _metadata if present in provided data
+        if isinstance(data, DataSet):
+            self.__finalize__(data)
+            
+        # Provided values for DataSet _metadata take precedence
         if spacegroup:
             self.spacegroup = spacegroup
         if cell:
@@ -102,9 +106,6 @@ class DataSet(pd.DataFrame):
         if merged is not None:
             self.merged = merged
             
-        # Build DataSet using DataFrame.__init__()
-        super().__init__(data=data, index=index, columns=columns,
-                         dtype=dtype, copy=copy)
         return
 
     #-------------------------------------------------------------------

--- a/reciprocalspaceship/dtypes/base.py
+++ b/reciprocalspaceship/dtypes/base.py
@@ -1,4 +1,3 @@
-import operator
 import numpy as np
 from pandas.core import nanops
 from pandas.core.indexers import check_array_indexer
@@ -13,7 +12,6 @@ from pandas.api.extensions import (
 from pandas.core.arrays.integer import IntegerArray, coerce_to_array
 from pandas.core.tools.numeric import to_numeric
 from pandas.util._decorators import cache_readonly
-from pandas.core.dtypes.cast import astype_nansafe
 import pandas as pd
 
 class MTZDtype(ExtensionDtype):
@@ -260,17 +258,6 @@ class NumpyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     @staticmethod
     def _box_scalar(scalar):
         return scalar
-
-    def astype(self, dtype, copy=True):
-        from pandas.core.arrays.string_ import StringDtype
-        
-        if isinstance(dtype, MTZDtype):
-            data = self._coerce_to_ndarray(dtype=dtype.type)
-        elif isinstance(dtype, StringDtype):
-            return dtype.construct_array_type()._from_sequence(self, copy=False)
-        else:
-            data = self._coerce_to_ndarray(dtype=dtype)
-        return astype_nansafe(data, dtype, copy=None)
     
     @classmethod
     def _concat_same_type(cls, to_concat):
@@ -278,9 +265,6 @@ class NumpyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
     def tolist(self):
         return self.data.tolist()
-
-    def argsort(self, axis=-1, kind='quicksort', order=None):
-        return self.data.argsort()
 
     def unique(self):
         _, indices = np.unique(self.data, return_index=True)

--- a/reciprocalspaceship/dtypes/base.py
+++ b/reciprocalspaceship/dtypes/base.py
@@ -12,6 +12,8 @@ from pandas.api.extensions import (
 from pandas.core.arrays.integer import IntegerArray, coerce_to_array
 from pandas.core.tools.numeric import to_numeric
 from pandas.util._decorators import cache_readonly
+from pandas.core.dtypes.cast import astype_nansafe
+from pandas.core.dtypes.common import is_dtype_equal
 import pandas as pd
 
 class MTZDtype(ExtensionDtype):
@@ -258,7 +260,38 @@ class NumpyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     @staticmethod
     def _box_scalar(scalar):
         return scalar
-    
+
+    def astype(self, dtype, copy=True):
+        """
+        Cast to a NumPy array with 'dtype'. Handles special case with 
+        MTZDtypes.
+
+        Parameters
+        ----------
+        dtype : str or dtype
+            Typecode or data-type to which the array is cast.
+        copy : bool, default True
+            Whether to copy the data, even if not necessary. If False,
+            a copy is made only if the old dtype does not match the
+            new dtype.
+
+        Returns
+        -------
+        array : ndarray
+            NumPy ndarray with 'dtype' for its dtype.
+        """
+        # Cannot defer to ExtensionArray.astype() due to call to coercion
+        # to dtype("float32")
+        if isinstance(dtype, MTZDtype):
+            if is_dtype_equal(dtype, self.dtype):
+                if not copy:
+                    return self
+                else:
+                    return self.copy()
+            else:
+                return dtype.construct_array_type()._from_sequence(self, copy=False)
+        return super().astype(dtype, copy=copy)
+        
     @classmethod
     def _concat_same_type(cls, to_concat):
         return cls(np.concatenate([array.data for array in to_concat]))

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     python_requires='>3.6',
     install_requires=[
         "gemmi >= 0.4.2",
-        "pandas >= 1.1.0,<1.2",
+        "pandas >= 1.1.4",
         "numpy",
         "scipy",
         "ipython",


### PR DESCRIPTION
This PR updates `reciprocalspaceship` to support the latest `pandas 1.2.0`. Based on testing, this supports versions 1.1.4 to latest, so I have adjusted our `install_requires` in `setup.py` to reflect that. 