### PR TITLE
Add DataSet.centrics and DataSet.acentrics accessors

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -149,7 +149,6 @@ class DataSet(pd.DataFrame):
         else:
             raise ValueError(f"Cannot construct gemmi.UnitCell from value: {val}")
             
-            
     @property
     def merged(self):
         """Whether DataSet contains merged reflection data (boolean)"""
@@ -159,6 +158,20 @@ class DataSet(pd.DataFrame):
     def merged(self, val):
         self._merged = val
 
+    @property
+    def centrics(self):
+        """Access centric reflections in DataSet"""
+        if 'CENTRIC' in self:
+            return self.loc[self.CENTRIC]
+        return self.loc[self.label_centrics().CENTRIC]
+
+    @property
+    def acentrics(self):
+        """Access acentric reflections in DataSet"""
+        if 'CENTRIC' in self:
+            return self.loc[~self.CENTRIC]
+        return self.loc[~self.label_centrics().CENTRIC]
+    
     #-------------------------------------------------------------------
     # Methods
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -203,16 +203,17 @@ def test_label_centrics(data_fmodel, inplace, no_sg):
         assert "CENTRIC" in result
         assert result["CENTRIC"].dtype.name == "bool"
 
+
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("no_sg", [True, False])
-def test_label_absences(data_fmodel, inplace, no_sg):
-    """Test DataSet.label_absences()"""
+def test_label_centrics(data_fmodel, inplace, no_sg):
+    """Test DataSet.label_centrics()"""
     if no_sg:
         data_fmodel.spacegroup = None
         with pytest.raises(ValueError):
-            result = data_fmodel.label_absences(inplace=inplace)
+            result = data_fmodel.label_centrics(inplace=inplace)
     else:
-        result = data_fmodel.label_absences(inplace=inplace)
+        result = data_fmodel.label_centrics(inplace=inplace)
 
         # Test inplace
         if inplace:
@@ -221,8 +222,42 @@ def test_label_absences(data_fmodel, inplace, no_sg):
             assert id(result) != id(data_fmodel)
             
         # Test centric column
-        assert "ABSENT" in result
-        assert result["ABSENT"].dtype.name == "bool"
+        assert "CENTRIC" in result
+        assert result["CENTRIC"].dtype.name == "bool"
+
+
+@pytest.mark.parametrize("cache", [True, False])
+def test_centrics(mtz_by_spacegroup, cache):
+    """Test DataSet.centrics against DataSet.label_centrics"""
+    ds =  rs.read_mtz(mtz_by_spacegroup)
+    if cache:
+        ds.label_centrics(inplace=True)
+        expected = ds.loc[ds.CENTRIC]
+        result = ds.centrics
+        assert "CENTRIC" in result
+    else:
+        expected = ds.loc[ds.label_centrics()["CENTRIC"]]
+        result = ds.centrics
+        assert "CENTRIC" not in result
+
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("cache", [True, False])
+def test_acentrics(mtz_by_spacegroup, cache):
+    """Test DataSet.acentrics against DataSet.label_centrics"""
+    ds =  rs.read_mtz(mtz_by_spacegroup)
+    if cache:
+        ds.label_centrics(inplace=True)
+        expected = ds.loc[~ds.CENTRIC]
+        result = ds.acentrics
+        assert "CENTRIC" in result
+    else:
+        expected = ds.loc[~ds.label_centrics()["CENTRIC"]]
+        result = ds.acentrics
+        assert "CENTRIC" not in result
+
+    assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize("inplace", [True, False])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -206,14 +206,14 @@ def test_label_centrics(data_fmodel, inplace, no_sg):
 
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("no_sg", [True, False])
-def test_label_centrics(data_fmodel, inplace, no_sg):
-    """Test DataSet.label_centrics()"""
+def test_label_absences(data_fmodel, inplace, no_sg):
+    """Test DataSet.label_absences()"""
     if no_sg:
         data_fmodel.spacegroup = None
         with pytest.raises(ValueError):
-            result = data_fmodel.label_centrics(inplace=inplace)
+            result = data_fmodel.label_absences(inplace=inplace)
     else:
-        result = data_fmodel.label_centrics(inplace=inplace)
+        result = data_fmodel.label_absences(inplace=inplace)
 
         # Test inplace
         if inplace:
@@ -222,8 +222,8 @@ def test_label_centrics(data_fmodel, inplace, no_sg):
             assert id(result) != id(data_fmodel)
             
         # Test centric column
-        assert "CENTRIC" in result
-        assert result["CENTRIC"].dtype.name == "bool"
+        assert "ABSENT" in result
+        assert result["ABSENT"].dtype.name == "bool"
 
 
 @pytest.mark.parametrize("cache", [True, False])


### PR DESCRIPTION
It is common to need to perform operations separately for centric and acentric reflections. This PR adds new attributes to `DataSet` that act as accessors to centric/acentric reflections. Internally, this operates by calling `DataSet.label_centrics()` and using the boolean mask to access the relevant rows of the reflection table. Centric reflections can be obtained by calling `DataSet.centrics` and acentric reflections can be obtained by calling `DataSet.acentrics`. 

It is worth keeping in mind that if one will be repeatedly accessing these properties, it is worthwhile to cache the results by saving the a `CENTRIC` column. These accessors will use the cached column if it exists instead of repeating the calculation. This can lead to dramatic performance improvements when working with large, unmerged DataSets. 