### PR TITLE
Add license file to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include LICENSE
 include reciprocalspaceship/VERSION


### PR DESCRIPTION
The license file is currently missing from the pypi distributions.