### PR TITLE
Add crystfel streams to `rs/io` module

### DIFF
--- a/reciprocalspaceship/__init__.py
+++ b/reciprocalspaceship/__init__.py
@@ -1,11 +1,8 @@
 # Version number for reciprocalspaceship
 def getVersionNumber():
     import pkg_resources
-
     version = pkg_resources.require("reciprocalspaceship")[0].version
     return version
-
-
 __version__ = getVersionNumber()
 
 # Top-Level API
@@ -21,21 +18,21 @@ from reciprocalspaceship import algorithms
 # Add support for MTZ data types:
 # see http://www.ccp4.ac.uk/html/f2mtz.html
 from .dtypes import (
-    HKLIndexDtype,  # H
-    IntensityDtype,  # J
-    StructureFactorAmplitudeDtype,  # F
-    AnomalousDifferenceDtype,  # D
-    StandardDeviationDtype,  # Q
-    FriedelStructureFactorAmplitudeDtype,  # G
-    StandardDeviationFriedelSFDtype,  # L
-    FriedelIntensityDtype,  # K
-    StandardDeviationFriedelIDtype,  # M
-    NormalizedStructureFactorAmplitudeDtype,  # E
-    PhaseDtype,  # P
-    WeightDtype,  # W
-    HendricksonLattmanDtype,  # A
-    BatchDtype,  # B
-    M_IsymDtype,  # Y
-    MTZIntDtype,  # I
-    MTZRealDtype,  # R
+    HKLIndexDtype,                           # H
+    IntensityDtype,                          # J
+    StructureFactorAmplitudeDtype,           # F
+    AnomalousDifferenceDtype,                # D
+    StandardDeviationDtype,                  # Q
+    FriedelStructureFactorAmplitudeDtype,    # G
+    StandardDeviationFriedelSFDtype,         # L
+    FriedelIntensityDtype,                   # K
+    StandardDeviationFriedelIDtype,          # M
+    NormalizedStructureFactorAmplitudeDtype, # E
+    PhaseDtype,                              # P
+    WeightDtype,                             # W
+    HendricksonLattmanDtype,                 # A
+    BatchDtype,                              # B
+    M_IsymDtype,                             # Y
+    MTZIntDtype,                             # I
+    MTZRealDtype                             # R
 )

--- a/reciprocalspaceship/__init__.py
+++ b/reciprocalspaceship/__init__.py
@@ -1,14 +1,17 @@
 # Version number for reciprocalspaceship
 def getVersionNumber():
     import pkg_resources
+
     version = pkg_resources.require("reciprocalspaceship")[0].version
     return version
+
+
 __version__ = getVersionNumber()
 
 # Top-Level API
 from .dataset import DataSet
 from .dataseries import DataSeries
-from .io import read_mtz, read_precognition, read_csv
+from .io import read_mtz, read_precognition, read_csv, read_crystfel
 from .dtypes import summarize_mtz_dtypes
 from .concat import concat
 
@@ -18,21 +21,21 @@ from reciprocalspaceship import algorithms
 # Add support for MTZ data types:
 # see http://www.ccp4.ac.uk/html/f2mtz.html
 from .dtypes import (
-    HKLIndexDtype,                           # H
-    IntensityDtype,                          # J
-    StructureFactorAmplitudeDtype,           # F
-    AnomalousDifferenceDtype,                # D
-    StandardDeviationDtype,                  # Q
-    FriedelStructureFactorAmplitudeDtype,    # G
-    StandardDeviationFriedelSFDtype,         # L
-    FriedelIntensityDtype,                   # K
-    StandardDeviationFriedelIDtype,          # M
-    NormalizedStructureFactorAmplitudeDtype, # E
-    PhaseDtype,                              # P
-    WeightDtype,                             # W
-    HendricksonLattmanDtype,                 # A
-    BatchDtype,                              # B
-    M_IsymDtype,                             # Y
-    MTZIntDtype,                             # I
-    MTZRealDtype                             # R
+    HKLIndexDtype,  # H
+    IntensityDtype,  # J
+    StructureFactorAmplitudeDtype,  # F
+    AnomalousDifferenceDtype,  # D
+    StandardDeviationDtype,  # Q
+    FriedelStructureFactorAmplitudeDtype,  # G
+    StandardDeviationFriedelSFDtype,  # L
+    FriedelIntensityDtype,  # K
+    StandardDeviationFriedelIDtype,  # M
+    NormalizedStructureFactorAmplitudeDtype,  # E
+    PhaseDtype,  # P
+    WeightDtype,  # W
+    HendricksonLattmanDtype,  # A
+    BatchDtype,  # B
+    M_IsymDtype,  # Y
+    MTZIntDtype,  # I
+    MTZRealDtype,  # R
 )

--- a/reciprocalspaceship/io/__init__.py
+++ b/reciprocalspaceship/io/__init__.py
@@ -7,5 +7,6 @@ from .mtz import (
 from .precognition import (
     read_precognition,
 )
+from .crystfel import (read_crystfel)
 from .ccp4map import write_ccp4_map
 from .csv import read_csv

--- a/reciprocalspaceship/io/crystfel.py
+++ b/reciprocalspaceship/io/crystfel.py
@@ -211,14 +211,14 @@ def read_crystfel(streamfile) -> DataSet:
     # set mtztypes as in precognition.py
     # hkl -- H
     # I, sigmaI -- J, Q
-    # BATCH -- I
+    # BATCH -- B
     # s1{x,y,z} -- R
     # ewald_offset -- R
     names = [
         'H', 'K', 'L', 'I', 'sigmaI', 'BATCH', 's1x', 's1y', 's1z',
         'ewald_offset'
     ]
-    mtztypes = ["H", "H", "H", "J", "Q", "I", "R", "R", "R", "R"]
+    mtztypes = ["H", "H", "H", "J", "Q", "B", "R", "R", "R", "R"]
     dataset = DataSet()
     for (k, v), mtztype in zip(df.items(), mtztypes):
         dataset[k] = v.astype(mtztype)

--- a/reciprocalspaceship/io/crystfel.py
+++ b/reciprocalspaceship/io/crystfel.py
@@ -1,0 +1,190 @@
+import pandas as pd
+from reciprocalspaceship import DataSet
+import numpy as np
+
+
+def _parse_stream(filename: str) -> dict:
+    """
+    Parses stream and returns all indexed peak positions
+
+    Arguments:
+        filename {str} -- input stream filename
+    """
+
+    answ_crystals = {}
+
+    def contains_filename(s):
+        return s.startswith("Image filename")
+
+    def contains_event(s):
+        return s.startswith("Event")
+
+    def contains_serial_number(s):
+        return s.startswith("Image serial number")
+
+    def starts_chunk_peaks(s):
+        return s.startswith("  fs/px   ss/px (1/d)/nm^-1   Intensity  Panel")
+
+    def ends_chunk_peaks(s):
+        return s.startswith("End of peak list")
+
+    def starts_crystal_peaks(s):
+        return s.startswith(
+            "   h    k    l          I   sigma(I)       peak background  fs/px  ss/px panel"
+        )
+
+    def is_photon_energy(s):
+        return s.startswith('photon_energy_eV')
+
+    def is_astar(s):
+        return s.startswith('astar')
+
+    def is_bstar(s):
+        return s.startswith('bstar')
+
+    def is_cstar(s):
+        return s.startswith('cstar')
+
+    def ends_crystal_peaks(s):
+        return s.startswith("End of reflections")
+
+    def eV2Angstrom(e_eV):
+        return 12398. / e_eV
+
+    with open(filename, "r") as stream:
+        is_chunk = False
+        is_crystal = False
+        current_filename = None
+        current_event = None  # to handle non-event streams
+        current_serial_number = None
+        corrupted_chunk = False
+        crystal_peak_number = 0
+        crystal_idx = 0
+
+        for line in stream:
+            # analyzing what we have
+            if ends_chunk_peaks(line):
+                is_chunk = False
+                chunk_peak_number = 0
+            elif ends_crystal_peaks(line):
+                is_crystal = False
+                crystal_peak_number = 0
+
+            elif is_photon_energy(line):
+                photon_energy = float(line.split()[2])
+            elif is_astar(line):
+                astar = np.array(list(map(
+                    float,
+                    line.split()[2:5]))) / 10.  # crystfel's notation uses nm-1
+            elif is_bstar(line):
+                bstar = np.array(list(map(
+                    float,
+                    line.split()[2:5]))) / 10.  # crystfel's notation uses nm-1
+            elif is_cstar(line):
+                cstar = np.array(list(map(
+                    float,
+                    line.split()[2:5]))) / 10.  # crystfel's notation uses nm-1
+
+                # since it's the last line needed to construct Ewald offset,
+                # we'll pre-compute the matrices here
+                A = np.array([astar, bstar, cstar]).T
+                lambda_inv = 1 / eV2Angstrom(photon_energy)
+                s0 = np.array([0, 0, lambda_inv]).T
+
+            elif is_crystal:
+                # example line:
+                #    h    k    l          I   sigma(I)       peak background  fs/px  ss/px panel
+                #  -63   41    9     -41.31      57.45     195.00     170.86  731.0 1350.4 p0
+                crystal_peak_number += 1
+                h, k, l, I, sigmaI, _, _, _, _, _ = [i for i in line.split()]
+                h, k, l = map(float, [h, k, l])
+
+                # calculate ewald offset and s1
+                hkl = np.array([h, k, l])
+                # print(A)
+                s1 = A @ hkl + s0
+                s1x, s1y, s1z = s1
+                ewald_offset = np.linalg.norm(s1) - lambda_inv
+
+                record = {
+                    "H": h,
+                    "K": k,
+                    "L": l,
+                    "I": float(I),
+                    "sigmaI": float(sigmaI),
+                    "BATCH": crystal_idx,
+                    's1x': s1x,
+                    's1y': s1y,
+                    's1z': s1z,
+                    'ewald_offset': ewald_offset
+                }
+                if current_event is not None:
+                    name = (current_filename, current_event,
+                            current_serial_number, crystal_idx, crystal_peak_number)
+                else:
+                    name = (current_filename, current_serial_number, crystal_idx,
+                            crystal_peak_number)
+                answ_crystals[name] = record
+
+            # start analyzing where we are now
+            if corrupted_chunk:
+                if "Begin chunk" not in line:
+                    continue
+                else:
+                    is_crystal, is_chunk = False, False
+                    corrupted_chunk = False
+                    continue
+
+            if contains_filename(line):
+                current_filename = line.split()[-1]
+            elif contains_event(line):
+                current_event = line.split()[-1][2:]
+            elif contains_serial_number(line):
+                current_serial_number = line.split()[-1]
+
+            elif starts_chunk_peaks(line):
+                is_chunk = True
+                continue
+
+            elif starts_crystal_peaks(line):
+                crystal_idx += 1
+                is_crystal = True
+                continue
+
+    return answ_crystals
+
+
+def read_crystfel(streamfile, logfile=None) -> DataSet:
+    """
+    Initialize attributes and populate the DataSet object with data from a CrystFEL stream with indexed reflections. This is the output format used by CrystFEL software when processing still diffraction data.
+
+    Parameters
+    ----------
+    streamfile : str of file
+        name of a .stream file or a file object
+    """
+
+    if not streamfile.endswith('.stream'):
+        raise ValueError("Stream file should end with .stream")
+    # read data from stream file
+    d = _parse_stream(streamfile)
+    df = pd.DataFrame.from_records(list(d.values()))
+
+    # set mtztypes as in precognition.py
+    # hkl -- H
+    # I, sigmaI -- J, Q
+    # BATCH -- I
+    # s1{x,y,z} -- R
+    # ewald_offset -- R
+    names = [
+        'H', 'K', 'L', 'I', 'sigmaI', 'BATCH', 's1x', 's1y', 's1z',
+        'ewald_offset'
+    ]
+    mtztypes = ["H", "H", "H", "J", "Q", "I", "R", "R", "R", "R"]
+    dataset = DataSet()
+    for (k, v), mtztype in zip(df.items(), mtztypes):
+        dataset[k] = v
+        dataset[k] = dataset[k].astype(mtztype)
+    dataset.set_index(['H', 'K', 'L'], inplace=True)
+
+    return dataset

--- a/reciprocalspaceship/io/crystfel.py
+++ b/reciprocalspaceship/io/crystfel.py
@@ -80,6 +80,7 @@ def _parse_stream(filename: str) -> dict:
                     be = get_cellparam(line)
                 if line.startswith('ga ='):
                     ga = get_cellparam(line)
+                    is_unit_cell = False # gamma is the last parameters
             elif 'End unit cell' in line:
                 rv_cell_param = np.array([a, b, c, al, be, ga])
                 break

--- a/tests/io/test_crystfel.py
+++ b/tests/io/test_crystfel.py
@@ -4,6 +4,7 @@ from os.path import dirname, abspath, join
 from os import remove
 import gemmi
 import reciprocalspaceship as rs
+import numpy as np
 
 
 def test_read_crystfel_mtz(IOtest_mtz):
@@ -19,7 +20,6 @@ class TestCrystFEL(unittest.TestCase):
     def test_read_stream(self):
 
         datadir = join(abspath(dirname(__file__)), '../data/crystfel')
-
 
         # Read HKL without providing cell / spacegroup
         hewl = rs.io.read_crystfel(join(datadir, 'crystfel.stream'))
@@ -37,7 +37,11 @@ class TestCrystFEL(unittest.TestCase):
         self.assertIsInstance(hewl["sigmaI"], rs.DataSeries)
         self.assertIsInstance(hewl["ewald_offset"], rs.DataSeries)
         self.assertIsNone(hewl.spacegroup)
-        self.assertIsNone(hewl.cell)
+        self.assertTrue(hewl.cell is not None)
+        self.assertTrue(
+            np.allclose(np.array(hewl.cell.parameters),
+                        np.array([79.20, 79.20, 38.00, 90.00, 90.00, 90.00]))
+        )  # use np.allclose to prevent stupid 1.000001 vs 1 errors of float conversion
 
         # chech values specific to the stream
         self.assertTrue(len(hewl.index.unique()) < len(hewl.index))

--- a/tests/io/test_crystfel.py
+++ b/tests/io/test_crystfel.py
@@ -15,7 +15,7 @@ def test_read_crystfel_mtz(IOtest_mtz):
         rs.io.read_crystfel(IOtest_mtz)
 
 
-class TestPrecognition(unittest.TestCase):
+class TestCrystFEL(unittest.TestCase):
     def test_read_stream(self):
 
         datadir = join(abspath(dirname(__file__)), '../data/crystfel')
@@ -44,6 +44,6 @@ class TestPrecognition(unittest.TestCase):
         self.assertTrue(
             hewl['ewald_offset'].min() < 0 < hewl['ewald_offset'].max())
         self.assertEqual(len(hewl.BATCH.unique()),
-                         2111)  # grep -c 'Begin crystal' crystfel.stream
+                         3)  # grep -c 'Begin crystal' crystfel.stream
 
         return

--- a/tests/io/test_crystfel.py
+++ b/tests/io/test_crystfel.py
@@ -1,0 +1,49 @@
+import unittest
+import pytest
+from os.path import dirname, abspath, join
+from os import remove
+import gemmi
+import reciprocalspaceship as rs
+
+
+def test_read_crystfel_mtz(IOtest_mtz):
+    """
+    rs.read_crystfel should raise ValueError when given file without
+    .stream suffix
+    """
+    with pytest.raises(ValueError):
+        rs.io.read_crystfel(IOtest_mtz)
+
+
+class TestPrecognition(unittest.TestCase):
+    def test_read_stream(self):
+
+        datadir = join(abspath(dirname(__file__)), '../data/crystfel')
+
+
+        # Read HKL without providing cell / spacegroup
+        hewl = rs.io.read_crystfel(join(datadir, 'crystfel.stream'))
+
+        self.assertEqual(list(hewl.index.names), ["H", "K", "L"])
+        self.assertTrue('I' in hewl.columns)
+        self.assertTrue('sigmaI' in hewl.columns)
+        self.assertTrue('BATCH' in hewl.columns)
+        self.assertTrue('s1x' in hewl.columns)
+        self.assertTrue('s1y' in hewl.columns)
+        self.assertTrue('s1z' in hewl.columns)
+        self.assertTrue('BATCH' in hewl.columns)
+        self.assertIsInstance(hewl, rs.DataSet)
+        self.assertIsInstance(hewl["I"], rs.DataSeries)
+        self.assertIsInstance(hewl["sigmaI"], rs.DataSeries)
+        self.assertIsInstance(hewl["ewald_offset"], rs.DataSeries)
+        self.assertIsNone(hewl.spacegroup)
+        self.assertIsNone(hewl.cell)
+
+        # chech values specific to the stream
+        self.assertTrue(len(hewl.index.unique()) < len(hewl.index))
+        self.assertTrue(
+            hewl['ewald_offset'].min() < 0 < hewl['ewald_offset'].max())
+        self.assertEqual(len(hewl.BATCH.unique()),
+                         2111)  # grep -c 'Begin crystal' crystfel.stream
+
+        return


### PR DESCRIPTION
This PR adds:
 - reading `CrystFEL's` stream files into `DataSet` format without any metadata
 - computing columns `ewald_offset`, `s1{x,y,z}` upon reading
 - accompanying tests
 - example of CrystFEL's stream to test on.