### PR TITLE
Clean up rs.read_precognition()

### DIFF
--- a/reciprocalspaceship/io/precognition.py
+++ b/reciprocalspaceship/io/precognition.py
@@ -2,8 +2,7 @@ import pandas as pd
 import gemmi
 from reciprocalspaceship import DataSet
 
-def read_precognition(hklfile, a=None, b=None, c=None, alpha=None,
-                      beta=None, gamma=None, sg=None, logfile=None):
+def read_precognition(hklfile, spacegroup=None, cell=None, logfile=None):
     """
     Initialize attributes and populate the DataSet object with data from
     a HKL file of reflections. This is the output format used by 
@@ -13,21 +12,11 @@ def read_precognition(hklfile, a=None, b=None, c=None, alpha=None,
     ----------
     hklfile : str or file
         name of an hkl file or a file object
-    a : float
-        edge length, a, of the unit cell
-    b : float
-        edge length, b, of the unit cell
-    c : float
-        edge length, c, of the unit cell
-    alpha : float
-        interaxial angle, alpha, of the unit cell
-    beta : float
-        interaxial angle, beta, of the unit cell
-    gamma : float
-        interaxial angle, gamma, of the unit cell
-    sg : str or int
+    spacegroup : str or int
         If int, this should specify the space group number. If str, 
         this should be a space group symbol
+    cell : tuple or list of floats
+        Unit cell parameters
     logfile : str or file
         name of a log file to parse to get cell parameters and sg
     """
@@ -70,6 +59,7 @@ def read_precognition(hklfile, a=None, b=None, c=None, alpha=None,
             a, b, c = map(float, lengths)
             angles  = lines[block-18].split()[-3:]
             alpha, beta, gamma = map(float, angles)
+            cell = (a, b, c, alpha, beta, gamma)
 
     # GH#32: Limit use to supported file formats
     else:
@@ -80,9 +70,9 @@ def read_precognition(hklfile, a=None, b=None, c=None, alpha=None,
     dataset.set_index(["H", "K", "L"], inplace=True)
 
     # Set DataSet attributes
-    if (a and b and c and alpha and beta and gamma):
-        dataset.cell = gemmi.UnitCell(a, b, c, alpha, beta, gamma)
-    if sg:
-        dataset.spacegroup = gemmi.SpaceGroup(sg)
+    if cell and (len(cell) == 6):
+        dataset.cell = cell
+    if spacegroup:
+        dataset.spacegroup = spacegroup
         
     return dataset

--- a/reciprocalspaceship/io/precognition.py
+++ b/reciprocalspaceship/io/precognition.py
@@ -2,7 +2,7 @@ import pandas as pd
 import gemmi
 from reciprocalspaceship import DataSet
 
-def read_precognition(hklfile,a=None, b=None, c=None, alpha=None,
+def read_precognition(hklfile, a=None, b=None, c=None, alpha=None,
                       beta=None, gamma=None, sg=None, logfile=None):
     """
     Initialize attributes and populate the DataSet object with data from
@@ -35,14 +35,14 @@ def read_precognition(hklfile,a=None, b=None, c=None, alpha=None,
     if hklfile.endswith(".hkl"):
         usecols = [0, 1, 2, 3, 4, 5, 6]
         F = pd.read_csv(hklfile, header=None, delim_whitespace=True,
-                        names=["H", "K", "L", "F+", "SigF+", "F-", "SigF-"],
+                        names=["H", "K", "L", "F(+)", "SigF(+)", "F(-)", "SigF(-)"],
                         usecols=usecols)
         mtztypes = ["H", "H", "H", "G", "L", "G", "L"]
 
         # Check if any anomalous data is actually included
-        if len(F["F-"].unique()) == 1: 
-            F = F[["H", "K", "L", "F+", "SigF+"]]
-            F.rename(columns={"F+":"F", "SigF+":"SigF"}, inplace=True)
+        if len(F["F(-)"].unique()) == 1: 
+            F = F[["H", "K", "L", "F(+)", "SigF(+)"]]
+            F.rename(columns={"F(+)":"F", "SigF(+)":"SigF"}, inplace=True)
             mtztypes = ["H", "H", "H", "F", "Q"]
 
     elif hklfile.endswith(".ii"):
@@ -75,10 +75,8 @@ def read_precognition(hklfile,a=None, b=None, c=None, alpha=None,
     else:
         raise ValueError("rs.read_precognition() only supports .ii and .hkl files")
             
-    dataset = DataSet()
-    for (k,v), mtztype in zip(F.items(), mtztypes):
-        dataset[k] = v
-        dataset[k] = dataset[k].astype(mtztype)
+    dataset = DataSet(F)
+    dataset = dataset.astype(dict(zip(dataset.columns, mtztypes)))
     dataset.set_index(["H", "K", "L"], inplace=True)
 
     # Set DataSet attributes

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -7,7 +7,7 @@ def IOtest_hkl():
     Path to Precognition .hkl file for I/O testing
     """
     datapath = join(abspath(dirname(__file__)), "../data/precognition")
-    return  join(datapath, "hewl.hkl")
+    return join(datapath, "hewl.hkl")
 
 @pytest.fixture
 def IOtest_ii():
@@ -15,7 +15,15 @@ def IOtest_ii():
     Path to Precognition .ii file for I/O testing
     """
     datapath = join(abspath(dirname(__file__)), "../data/precognition")
-    return  join(datapath, "e074a_off1_001.mccd.ii")
+    return join(datapath, "e074a_off1_001.mccd.ii")
+
+@pytest.fixture
+def IOtest_log():
+    """
+    Path to Precognition integration logfile for I/O testing
+    """
+    datapath = join(abspath(dirname(__file__)), "../data/precognition")
+    return join(datapath, "integration.log")
 
 @pytest.fixture
 def IOtest_mtz():


### PR DESCRIPTION
This PR cleans up `rs.read_precognition()` to better adhere to the style of the rest of `rs`:

- Changes API to accept unit cell parameters as a tuple/list-like of floats
- Changes anomalous columns to use `(+)`-style suffixes rather than `+`
- Minor refactor to use `DataSet.astype()` to set MTZDtypes for the columns
- Refactors tests to use `pytest` functional style rather than the `unittest` style classes 