### PR TITLE
Add example notebooks' dependencies to dev install

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,3 +1,2 @@
 # Add binder requirements that are not dependencies
-conda install -c conda-forge matplotlib seaborn tqdm scikit-image -y
-conda install pytorch -c pytorch
+pip install reciprocalspaceship[dev]

--- a/setup.py
+++ b/setup.py
@@ -57,12 +57,21 @@ setup(
     tests_require=['pytest', 'pytest-cov', 'pytest-xdist'],
     extras_require={
         'dev': [
+            # sphinx documentation
             "sphinx",
             "sphinx_rtd_theme",
             "nbsphinx",
             "sphinx-panels",
             "sphinxcontrib-autoprogram",
             "jupyter",
+
+            # example notebooks
+            "tqdm",
+            "matplotlib",
+            "seaborn",
+            "celluloid",
+            "scikit-image",
+            "torch",
         ]
     },
     entry_points={


### PR DESCRIPTION
This PR updates the "dev" build to include all extra dependencies that are needed to run the example notebooks. The dev build can be done using `pip` and a local clone of the git repo:
```shell
pip install -e .[dev]
```
or using PyPI:
```shell
pip install reciprocalspaceship[dev]
```

The `postBuild` script that is used to initialize the binder environment was also updated to use this set of extra dependencies.

Two benefits of this PR are:

1. Extra dependencies for documentation/examples only need to be updated in one place
2. It is possible to automate the "re-running" of example notebooks at each official release ensure the examples are up-to-date.