### PR TITLE
clearer error message in `to_gemmi`

### DIFF
--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -107,7 +107,7 @@ def to_gemmi(dataset, skip_problem_mtztypes=False):
         elif skip_problem_mtztypes:
             continue
         else:
-            raise ValueError(f"column of type {cseries.dtype} cannot be written to an MTZ file. "
+            raise ValueError(f"column {c} of type {cseries.dtype} cannot be written to an MTZ file. "
                              f"To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True")
     mtz.set_data(temp[columns].to_numpy(dtype="float32"))
 


### PR DESCRIPTION
When `rs` runs into trouble converting a column to a `gemmi` compatible `dtype`, it is helpful to know the column name in addition to the offending dtype. 