### PR TITLE
Adding methods for interconverting wavelength and energy

### DIFF
--- a/reciprocalspaceship/utils/__init__.py
+++ b/reciprocalspaceship/utils/__init__.py
@@ -9,3 +9,4 @@ from .rfree import add_rfree, copy_rfree
 from .asu import hkl_to_asu, hkl_to_observed, in_asu
 from .cell import compute_dHKL
 from .binning import bin_by_percentile
+from .units import ev2angstroms, angstroms2ev

--- a/reciprocalspaceship/utils/units.py
+++ b/reciprocalspaceship/utils/units.py
@@ -1,0 +1,10 @@
+from scipy.constants import Planck, c, electron_volt
+
+
+def ev2angstroms(ev):
+    return Planck * c / ev / 1e-10 / electron_volt
+
+def angstroms2ev(angstroms):
+    return Planck * c / angstroms / 1e-10 / electron_volt
+
+

--- a/tests/utils/test_units.py
+++ b/tests/utils/test_units.py
@@ -1,0 +1,13 @@
+import reciprocalspaceship as rs
+import numpy as np
+
+
+def test_ev2angstroms():
+    angstroms = np.linspace(0.1, 100, 1000)
+    ev = rs.utils.angstroms2ev(angstroms)
+    assert np.allclose(ev*angstroms, 12398.41984332)
+
+def test_angstroms2ev():
+    ev = np.linspace(1000., 50000., 1000)
+    angstroms = rs.utils.angstroms2ev(ev)
+    assert np.allclose(ev*angstroms, 12398.41984332)


### PR DESCRIPTION
This PR will add two new methods to `rs.utils`, `ev2angstroms` and `angstroms2ev`. 