### PR TITLE
Change internals for representing float32-backed data

### DIFF
--- a/reciprocalspaceship/dtypes/anomalousdifference.py
+++ b/reciprocalspaceship/dtypes/anomalousdifference.py
@@ -1,8 +1,8 @@
 from pandas.core.dtypes.dtypes import register_extension_dtype
-from .base import NumpyExtensionArray, NumpyFloat32ExtensionDtype
+from .base import MTZFloatArray, MTZFloat32Dtype
 
 @register_extension_dtype
-class AnomalousDifferenceDtype(NumpyFloat32ExtensionDtype):
+class AnomalousDifferenceDtype(MTZFloat32Dtype):
     """Dtype for anomalous difference data in reflection tables"""
     name = 'AnomalousDifference'
     mtztype = "D"
@@ -11,7 +11,7 @@ class AnomalousDifferenceDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return AnomalousDifferenceArray
 
-class AnomalousDifferenceArray(NumpyExtensionArray):
+class AnomalousDifferenceArray(MTZFloatArray):
     """ExtensionArray for supporting AnomalousDifferenceDtype"""
     _dtype = AnomalousDifferenceDtype()
     pass

--- a/reciprocalspaceship/dtypes/base.py
+++ b/reciprocalspaceship/dtypes/base.py
@@ -1,22 +1,11 @@
 import numpy as np
-from pandas.core import nanops
-from pandas.core.indexers import check_array_indexer
-from pandas.core.construction import extract_array
 from pandas._libs import lib, missing as libmissing
-from pandas.api.extensions import (
-    ExtensionDtype,
-    ExtensionArray,
-    ExtensionScalarOpsMixin,
-    take
-)
+from pandas.api.extensions import ExtensionDtype
 from pandas.core.arrays.integer import IntegerArray
 from pandas.core.arrays.integer import coerce_to_array as coerce_to_int_array
 from pandas.core.arrays.floating import FloatingArray
 from pandas.core.arrays.floating import coerce_to_array as coerce_to_float_array
-from pandas.core.tools.numeric import to_numeric
 from pandas.util._decorators import cache_readonly
-from pandas.core.dtypes.cast import astype_nansafe
-from pandas.core.dtypes.common import is_dtype_equal
 import pandas as pd
 
 class MTZDtype(ExtensionDtype):
@@ -180,6 +169,47 @@ class MTZFloatArray(FloatingArray):
     def _coerce_to_array(self, value):
         return coerce_to_float_array(value, dtype=self.dtype)
 
+    def to_numpy(self, dtype=None, copy=False, na_value=lib.no_default):
+        """
+        Convert to a NumPy Array.
+
+        If array does not contain any NaN values, will return a np.int32
+        ndarray. If array contains NaN values, will return a ndarray of 
+        object dtype.
+
+        Parameters
+        ----------
+        dtype : dtype, default np.int32 or np.float32
+            The numpy dtype to return
+        copy : bool, default False
+            Whether to ensure that the returned value is a not a view on
+            the array. Note that ``copy=False`` does not *ensure* that
+            ``to_numpy()`` is no-copy. Rather, ``copy=True`` ensure that
+            a copy is made, even if not strictly necessary. This is typically
+            only possible when no missing values are present and `dtype`
+            is the equivalent numpy dtype.
+        na_value : scalar, optional
+             Scalar missing value indicator to use in numpy array. Defaults
+             to the native missing value indicator of this array.
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+        if na_value is lib.no_default:
+            na_value = libmissing.NA
+
+        if dtype is None:
+            dtype = np.float32
+
+        if self._hasna:
+            data = self._data.astype(dtype, copy=copy)
+            data[self._mask] = na_value
+        else:
+            data = self._data.astype(dtype, copy=copy)
+
+        return data
+    
     def value_counts(self, dropna=True):
         """
         Returns a DataSeries containing counts of each category.

--- a/reciprocalspaceship/dtypes/base.py
+++ b/reciprocalspaceship/dtypes/base.py
@@ -9,7 +9,10 @@ from pandas.api.extensions import (
     ExtensionScalarOpsMixin,
     take
 )
-from pandas.core.arrays.integer import IntegerArray, coerce_to_array
+from pandas.core.arrays.integer import IntegerArray
+from pandas.core.arrays.integer import coerce_to_array as coerce_to_int_array
+from pandas.core.arrays.floating import FloatingArray
+from pandas.core.arrays.floating import coerce_to_array as coerce_to_float_array
 from pandas.core.tools.numeric import to_numeric
 from pandas.util._decorators import cache_readonly
 from pandas.core.dtypes.cast import astype_nansafe
@@ -27,6 +30,7 @@ class MTZDtype(ExtensionDtype):
             raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
         return cls()
 
+
 class MTZInt32Dtype(MTZDtype, pd.Int32Dtype):
     """Base ExtensionDtype class for MTZDtype backed by pd.Int32Dtype"""
 
@@ -40,6 +44,7 @@ class MTZInt32Dtype(MTZDtype, pd.Int32Dtype):
     def __repr__(self):
         return self.name
 
+
 class MTZIntegerArray(IntegerArray):
 
     @cache_readonly
@@ -48,12 +53,12 @@ class MTZIntegerArray(IntegerArray):
 
     @classmethod
     def _from_sequence(cls, scalars, dtype=None, copy=False):
-        values, mask = coerce_to_array(scalars, dtype=dtype, copy=copy)
+        values, mask = coerce_to_int_array(scalars, dtype=dtype, copy=copy)
         return cls(values, mask)
 
     @classmethod
     def _from_factorized(cls, values, original):
-        values, mask = coerce_to_array(values, dtype=original.dtype)
+        values, mask = coerce_to_int_array(values, dtype=original.dtype)
         return cls(values, mask)
 
     def reshape(self, *args, **kwargs):
@@ -146,174 +151,34 @@ class MTZIntegerArray(IntegerArray):
 
         return rs.DataSeries(array, index=index)
 
+
+class MTZFloat32Dtype(MTZDtype, pd.Float32Dtype):
+    """Base ExtensionDtype class for MTZDtype backed by pd.Float32Dtype"""
+
+    def _get_common_dtype(self, dtypes):
+        if len(set(dtypes)) == 1:
+            # only itself
+            return self
+        else:
+            return super(pd.Float32Dtype, self)._get_common_dtype(dtypes)
     
-class NumpyFloat32ExtensionDtype(MTZDtype):
-    """Base ExtensionDtype class for generic MTZDtype backed by np.float32"""
+    def __repr__(self):
+        return self.name
 
-    type = np.float32
-    kind = 'f'
-    na_value = np.nan
 
-    @property
-    def _is_numeric(self):
-        return True
+class MTZFloatArray(FloatingArray):
 
     @cache_readonly
-    def numpy_dtype(self):
-        """ Return an instance of our numpy dtype """
-        return np.dtype(self.type)
-
-    @cache_readonly
-    def itemsize(self):
-        """ Return the number of bytes in this dtype """
-        return self.numpy_dtype.itemsize
-
-class NumpyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
-    """
-    Base ExtensionArray for defining a custom Pandas.ExtensionDtype that
-    uses a numpy array on the backend for storing the array data.
-    """
-    _itemsize = 8
-    ndim = 1
-    can_hold_na = True
-    __array_priority__ = 1000
-
-    def __init__(self, values, copy=False, dtype=None):
-        self.data = np.array(values, dtype=self._dtype.type, copy=copy)
-    
-    @property
     def dtype(self):
         return self._dtype
 
     @classmethod
     def _from_sequence(cls, scalars, dtype=None, copy=False):
-        return cls(scalars, copy=copy, dtype=dtype)
+        values, mask = coerce_to_float_array(scalars, dtype=dtype, copy=copy)
+        return cls(values, mask)
 
-    @classmethod
-    def _from_sequence_of_strings(cls, strings, dtype=None, copy=False):
-        scalars = to_numeric(strings, errors="raise")
-        return cls._from_sequence(scalars, dtype, copy)
-    
-    @classmethod
-    def _from_factorized(cls, values, original):
-        return cls(values)
-
-    @classmethod
-    def _from_ndarray(cls, data, copy=False):
-        return cls(data, copy=copy)
-
-    @property
-    def shape(self):
-        return self.data.shape
-
-    @property
-    def na_value(self):
-        return self.dtype.na_value
-    
-    def __len__(self):
-        return len(self.data)
-
-    def __getitem__(self, item):
-        item = check_array_indexer(self, item)
-
-        result = self.data[item]
-        if not lib.is_scalar(item):
-            result = type(self)(result)
-        return result
-
-    @property
-    def nbytes(self):
-        return self._itemsize * len(self)
-
-    def reshape(self, *args, **kwargs):
-        return self.data.reshape(*args, **kwargs)
-    
-    def _formatter(self, boxed=False):
-        def fmt(x):
-            if np.isnan(x):
-                return "NaN"
-            return str(x)
-        return fmt
-
-    def copy(self, deep=False):
-        return type(self)(self.data.copy())
-
-    def __setitem__(self, key, value):
-        value = extract_array(value, extract_numpy=True)
-
-        key = check_array_indexer(self, key)
-        scalar_value = lib.is_scalar(value)
-
-        if not scalar_value:
-            value = np.asarray(value, dtype=self.data.dtype)
-
-        self.data[key] = value
-
-    def isna(self):
-        return np.isnan(self.data)
-
-    def take(self, indexer, allow_fill=False, fill_value=None):
-        took = take(self.data, indexer, allow_fill=allow_fill,
-                    fill_value=fill_value)
-        return type(self)(took)
-
-    @staticmethod
-    def _box_scalar(scalar):
-        return scalar
-
-    def astype(self, dtype, copy=True):
-        """
-        Cast to a NumPy array with 'dtype'. Handles special case with 
-        MTZDtypes.
-
-        Parameters
-        ----------
-        dtype : str or dtype
-            Typecode or data-type to which the array is cast.
-        copy : bool, default True
-            Whether to copy the data, even if not necessary. If False,
-            a copy is made only if the old dtype does not match the
-            new dtype.
-
-        Returns
-        -------
-        array : ndarray
-            NumPy ndarray with 'dtype' for its dtype.
-        """
-        # Cannot defer to ExtensionArray.astype() due to call to coercion
-        # to dtype("float32")
-        if isinstance(dtype, MTZDtype):
-            if is_dtype_equal(dtype, self.dtype):
-                if not copy:
-                    return self
-                else:
-                    return self.copy()
-            else:
-                return dtype.construct_array_type()._from_sequence(self, copy=False)
-        return super().astype(dtype, copy=copy)
-        
-    @classmethod
-    def _concat_same_type(cls, to_concat):
-        return cls(np.concatenate([array.data for array in to_concat]))
-
-    def tolist(self):
-        return self.data.tolist()
-
-    def unique(self):
-        _, indices = np.unique(self.data, return_index=True)
-        data = self.data.take(np.sort(indices))
-        return self._from_ndarray(data)
-
-    def __iter__(self):
-        return iter(self.data)
-
-    def _reduce(self, name, skipna=True, **kwargs):
-        data = self.data
-
-        op = getattr(nanops, 'nan' + name)
-        result = op(data, axis=0, skipna=skipna)
-
-        return result
+    def _coerce_to_array(self, value):
+        return coerce_to_float_array(value, dtype=self.dtype)
 
     def value_counts(self, dropna=True):
         """
@@ -333,8 +198,7 @@ class NumpyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         import reciprocalspaceship as rs
 
         # compute counts on the data with no nans
-        mask = np.isnan(self.data)
-        data = self.data[~mask]
+        data = self._data[~self._mask]
         value_counts = Index(data).value_counts()
         array = value_counts.values
 
@@ -349,7 +213,7 @@ class NumpyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             # TODO(extension)
             # appending to an Index *always* infers
             # w/o passing the dtype
-            array = np.append(array, [mask.sum()])
+            array = np.append(array, [self._mask.sum()])
             index = Index(
                 np.concatenate(
                     [index.values, np.array([self.dtype.na_value], dtype=object)]
@@ -358,16 +222,3 @@ class NumpyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             )
 
         return rs.DataSeries(array, index=index)
-
-    def _coerce_to_ndarray(self, dtype=None):
-        if dtype:
-            data = self.data.astype(dtype)
-        else:
-            data = self.data.astype(self.dtype.type)
-        return data
-
-    def __array__(self, dtype=None):
-        return self._coerce_to_ndarray(dtype=dtype)
-
-NumpyExtensionArray._add_arithmetic_ops()
-NumpyExtensionArray._add_comparison_ops()

--- a/reciprocalspaceship/dtypes/intensity.py
+++ b/reciprocalspaceship/dtypes/intensity.py
@@ -1,8 +1,8 @@
 from pandas.core.dtypes.dtypes import register_extension_dtype
-from .base import NumpyExtensionArray, NumpyFloat32ExtensionDtype
+from .base import MTZFloatArray, MTZFloat32Dtype
 
 @register_extension_dtype
-class IntensityDtype(NumpyFloat32ExtensionDtype):
+class IntensityDtype(MTZFloat32Dtype):
     """Dtype for Intensity data in reflection tables"""
     name = 'Intensity'
     mtztype = "J"
@@ -11,13 +11,13 @@ class IntensityDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return IntensityArray
 
-class IntensityArray(NumpyExtensionArray):
+class IntensityArray(MTZFloatArray):
     """ExtensionArray for supporting IntensityDtype"""    
     _dtype = IntensityDtype()
     pass
 
 @register_extension_dtype
-class FriedelIntensityDtype(NumpyFloat32ExtensionDtype):
+class FriedelIntensityDtype(MTZFloat32Dtype):
     """Dtype for I(+) or I(-) data in reflection tables"""
     name = 'FriedelIntensity'
     mtztype = "K"
@@ -26,7 +26,7 @@ class FriedelIntensityDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return FriedelIntensityArray
 
-class FriedelIntensityArray(NumpyExtensionArray):
+class FriedelIntensityArray(MTZFloatArray):
     """ExtensionArray for supporting FriedelIntensityDtype"""
     _dtype = FriedelIntensityDtype()
     pass

--- a/reciprocalspaceship/dtypes/mtzreal.py
+++ b/reciprocalspaceship/dtypes/mtzreal.py
@@ -1,8 +1,8 @@
 from pandas.core.dtypes.dtypes import register_extension_dtype
-from .base import NumpyExtensionArray, NumpyFloat32ExtensionDtype
+from .base import MTZFloatArray, MTZFloat32Dtype
 
 @register_extension_dtype
-class MTZRealDtype(NumpyFloat32ExtensionDtype):
+class MTZRealDtype(MTZFloat32Dtype):
     """Dtype for generic MTZ real data"""
     
     name = 'MTZReal'
@@ -12,7 +12,7 @@ class MTZRealDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return MTZRealArray
 
-class MTZRealArray(NumpyExtensionArray):
+class MTZRealArray(MTZFloatArray):
     """ExtensionArray for supporting MtzRealDtype"""
     _dtype = MTZRealDtype()
     pass

--- a/reciprocalspaceship/dtypes/phase.py
+++ b/reciprocalspaceship/dtypes/phase.py
@@ -1,8 +1,8 @@
 from pandas.core.dtypes.dtypes import register_extension_dtype
-from .base import NumpyExtensionArray, NumpyFloat32ExtensionDtype
+from .base import MTZFloatArray, MTZFloat32Dtype
 
 @register_extension_dtype
-class PhaseDtype(NumpyFloat32ExtensionDtype):
+class PhaseDtype(MTZFloat32Dtype):
     """Dtype for representing phase data in reflection tables"""
     name = 'Phase'
     mtztype = "P"
@@ -11,13 +11,13 @@ class PhaseDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return PhaseArray
     
-class PhaseArray(NumpyExtensionArray):
+class PhaseArray(MTZFloatArray):
     """ExtensionArray for supporting PhaseDtype"""
     _dtype = PhaseDtype()
     pass
 
 @register_extension_dtype
-class HendricksonLattmanDtype(NumpyFloat32ExtensionDtype):
+class HendricksonLattmanDtype(MTZFloat32Dtype):
     """
     Dtype for representing phase probability coefficients 
     (Hendrickson-Lattman) in reflection tables
@@ -29,7 +29,7 @@ class HendricksonLattmanDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return HendricksonLattmanArray
 
-class HendricksonLattmanArray(NumpyExtensionArray):
+class HendricksonLattmanArray(MTZFloatArray):
     """ExtensionArray for supporting HendricksonLattmanDtype"""
     _dtype = HendricksonLattmanDtype()
     pass

--- a/reciprocalspaceship/dtypes/stddev.py
+++ b/reciprocalspaceship/dtypes/stddev.py
@@ -1,8 +1,8 @@
 from pandas.core.dtypes.dtypes import register_extension_dtype
-from .base import NumpyExtensionArray, NumpyFloat32ExtensionDtype
+from .base import MTZFloatArray, MTZFloat32Dtype
 
 @register_extension_dtype
-class StandardDeviationDtype(NumpyFloat32ExtensionDtype):
+class StandardDeviationDtype(MTZFloat32Dtype):
     """Dtype for standard deviation of observables: J, F, D or other"""
     name = 'Stddev'
     mtztype = "Q"
@@ -11,13 +11,13 @@ class StandardDeviationDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return StandardDeviationArray
 
-class StandardDeviationArray(NumpyExtensionArray):
+class StandardDeviationArray(MTZFloatArray):
     """ExtensionArray for supporting StandardDeviationDtype"""    
     _dtype = StandardDeviationDtype()
     pass
 
 @register_extension_dtype
-class StandardDeviationFriedelSFDtype(NumpyFloat32ExtensionDtype):
+class StandardDeviationFriedelSFDtype(MTZFloat32Dtype):
     """Dtype for standard deviation of F(+) or F(-)"""
     name = 'StddevFriedelSF'
     mtztype = "L"
@@ -26,13 +26,13 @@ class StandardDeviationFriedelSFDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return StandardDeviationFriedelSFArray
 
-class StandardDeviationFriedelSFArray(NumpyExtensionArray):
+class StandardDeviationFriedelSFArray(MTZFloatArray):
     """ExtensionArray for supporting StandardDeviationFriedelSFDtype"""
     _dtype = StandardDeviationFriedelSFDtype()
     pass
 
 @register_extension_dtype
-class StandardDeviationFriedelIDtype(NumpyFloat32ExtensionDtype):
+class StandardDeviationFriedelIDtype(MTZFloat32Dtype):
     """Dtype for standard deviation of I(+) or I(-)"""
     name = 'StddevFriedelI'
     mtztype = "M"
@@ -41,7 +41,7 @@ class StandardDeviationFriedelIDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return StandardDeviationFriedelIArray
 
-class StandardDeviationFriedelIArray(NumpyExtensionArray):
+class StandardDeviationFriedelIArray(MTZFloatArray):
     """ExtensionArray for supporting StandardDeviationFriedelIDtype"""
     _dtype = StandardDeviationFriedelIDtype()
     pass

--- a/reciprocalspaceship/dtypes/structurefactor.py
+++ b/reciprocalspaceship/dtypes/structurefactor.py
@@ -1,8 +1,8 @@
 from pandas.core.dtypes.dtypes import register_extension_dtype
-from .base import NumpyExtensionArray, NumpyFloat32ExtensionDtype
+from .base import MTZFloatArray, MTZFloat32Dtype
 
 @register_extension_dtype
-class StructureFactorAmplitudeDtype(NumpyFloat32ExtensionDtype):
+class StructureFactorAmplitudeDtype(MTZFloat32Dtype):
     """Dtype for structure factor amplitude  data"""
     name = 'SFAmplitude'
     mtztype = "F"
@@ -11,13 +11,13 @@ class StructureFactorAmplitudeDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return StructureFactorAmplitudeArray
 
-class StructureFactorAmplitudeArray(NumpyExtensionArray):
+class StructureFactorAmplitudeArray(MTZFloatArray):
     """ExtensionArray for supporting StructureFactorAmplitudeDtype"""
     _dtype = StructureFactorAmplitudeDtype()
     pass
 
 @register_extension_dtype
-class FriedelStructureFactorAmplitudeDtype(NumpyFloat32ExtensionDtype):
+class FriedelStructureFactorAmplitudeDtype(MTZFloat32Dtype):
     """
     Dtype for structure factor amplitude data from Friedel pairs -- 
     F(+) or F(-)
@@ -29,13 +29,13 @@ class FriedelStructureFactorAmplitudeDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return FriedelStructureFactorAmplitudeArray
 
-class FriedelStructureFactorAmplitudeArray(NumpyExtensionArray):
+class FriedelStructureFactorAmplitudeArray(MTZFloatArray):
     """ExtensionArray for supporting FriedelStructureFactorAmplitudeDtype"""
     _dtype = FriedelStructureFactorAmplitudeDtype()
     pass
 
 @register_extension_dtype
-class NormalizedStructureFactorAmplitudeDtype(NumpyFloat32ExtensionDtype):
+class NormalizedStructureFactorAmplitudeDtype(MTZFloat32Dtype):
     """Dtype for normalized structure factor amplitude data"""
     name = 'NormalizedSFAmplitude'
     mtztype = "E"
@@ -44,7 +44,7 @@ class NormalizedStructureFactorAmplitudeDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return NormalizedStructureFactorAmplitudeArray
 
-class NormalizedStructureFactorAmplitudeArray(NumpyExtensionArray):
+class NormalizedStructureFactorAmplitudeArray(MTZFloatArray):
     """ExtensionArray for supporting NormalizedStructureFactorAmplitudeDtype"""
     _dtype = NormalizedStructureFactorAmplitudeDtype()
     pass

--- a/reciprocalspaceship/dtypes/weight.py
+++ b/reciprocalspaceship/dtypes/weight.py
@@ -1,8 +1,8 @@
 from pandas.core.dtypes.dtypes import register_extension_dtype
-from .base import NumpyExtensionArray, NumpyFloat32ExtensionDtype
+from .base import MTZFloatArray, MTZFloat32Dtype
 
 @register_extension_dtype
-class WeightDtype(NumpyFloat32ExtensionDtype):
+class WeightDtype(MTZFloat32Dtype):
     """Dtype for representing weights"""
     name = 'Weight'
     mtztype = "W"
@@ -11,7 +11,7 @@ class WeightDtype(NumpyFloat32ExtensionDtype):
     def construct_array_type(cls):
         return WeightArray
 
-class WeightArray(NumpyExtensionArray):
+class WeightArray(MTZFloatArray):
     """ExtensionArray for supporting WeightDtype"""
     _dtype = WeightDtype()
     pass

--- a/tests/dtypes/test_dtypes.py
+++ b/tests/dtypes/test_dtypes.py
@@ -15,10 +15,12 @@ def test_numpy_dtype(dtype_floats):
     """Test NumpyFloat32ExtensionDtype.numpy_dtype"""
     assert dtype_floats[0]().numpy_dtype == dtype_floats[0]().type
 
+@pytest.mark.xfail
 def test_numpy_navalue(data_float):
     """Test NumpyExtensionArray.na_value returns np.nan"""
     assert data_float.na_value is np.nan
 
+@pytest.mark.xfail
 def test_numpy_tolist(data_float):
     """Test NumpyExtensionArray.tolist() returns list"""
     result = data_float.tolist()

--- a/tests/dtypes/test_floats_pandas.py
+++ b/tests/dtypes/test_floats_pandas.py
@@ -47,23 +47,23 @@ def dtype(request):
 
 @pytest.fixture
 def data(dtype):
-    return array[dtype.name](np.arange(0, 100), dtype=dtype)
+    return array[dtype.name]._from_sequence(np.arange(0, 100), dtype=dtype)
 
 @pytest.fixture
 def data_for_twos(dtype):
-    return array[dtype.name](np.ones(100) * 2, dtype=dtype)
+    return array[dtype.name]._from_sequence(np.ones(100) * 2, dtype=dtype)
 
 @pytest.fixture
 def data_missing(dtype):
-    return array[dtype.name]([np.nan, 1.], dtype=dtype)
+    return array[dtype.name]._from_sequence([np.nan, 1.], dtype=dtype)
 
 @pytest.fixture
 def data_for_sorting(dtype):
-    return array[dtype.name]([1., 2., 0.], dtype=dtype)
+    return array[dtype.name]._from_sequence([1., 2., 0.], dtype=dtype)
 
 @pytest.fixture
 def data_missing_for_sorting(dtype):
-    return array[dtype.name]([1., np.nan, 0.], dtype=dtype)
+    return array[dtype.name]._from_sequence([1., np.nan, 0.], dtype=dtype)
 
 @pytest.fixture(params=['data', 'data_missing'])
 def all_data(request, data, data_missing):
@@ -79,7 +79,7 @@ def data_for_grouping(dtype):
     a = 0
     c = 2
     na = np.nan
-    return array[dtype.name]([b, b, na, na, a, a, b, c], dtype=dtype)
+    return array[dtype.name]._from_sequence([b, b, na, na, a, a, b, c], dtype=dtype)
 
 class TestCasting(base.BaseCastingTests):
     pass
@@ -123,22 +123,6 @@ class TestMethods(base.BaseMethodsTests):
         
         self.assert_series_equal(result, expected)
 
-    def test_combine_le(self, data_repeated):
-        """
-        pd.Series.combine() returns Series with original dtype when an 
-        ExtensionArray is used. This test needed to be updated to reflect
-        that behavior.
-        """
-        orig_data1, orig_data2 = data_repeated(2)
-        s1 = rs.DataSeries(orig_data1)
-        s2 = rs.DataSeries(orig_data2)
-        result = s1.combine(s2, lambda x1, x2: x1 <= x2)
-        expected = rs.DataSeries(
-            [a <= b for (a, b) in zip(list(orig_data1), list(orig_data2))],
-            dtype=s1.dtype
-        )
-        self.assert_series_equal(result, expected)
-
     def test_value_counts_with_normalize(self, data):
         # GH 33172
         data = data[:10].unique()
@@ -157,7 +141,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         if exc is None:
             result = op(s, other)
             # Override to do the astype to boolean
-            expected = s.combine(other, op).astype(bool)
+            expected = s.combine(other, op).astype("boolean")
             self.assert_series_equal(result, expected)
         else:
             with pytest.raises(exc):

--- a/tests/utils/test_phases.py
+++ b/tests/utils/test_phases.py
@@ -25,6 +25,10 @@ def test_canonicalize_phases(phase_deg, deg):
         phase_deg = np.deg2rad(phase_deg)
         expected_phase = np.deg2rad(expected_phase)
     p = rs.utils.canonicalize_phases(phase_deg, deg)
+    if isinstance(p, rs.DataSeries):
+        p = p.to_numpy(np.float32)
+        expected_phase = expected_phase.to_numpy(np.float32)
+        
     assert np.allclose(p, expected_phase)
 
 


### PR DESCRIPTION
Recently, there appears to have been a change in Pandas that has made our float32-backed dtypes notably slower than native numpy dtypes:

```
In [1] x = rs.DataSeries(np.linspace(0, 1, 1000000), dtype=np.float32)

In [2]: %timeit x / 100
1.97 ms ± 140 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [3]: x = rs.DataSeries(np.linspace(0, 1, 1000000), dtype="MTZReal")

In [4]: %timeit x / 100
2.89 s ± 186 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

This PR fixes this ~1000-2000x slowdown by reimplementing our float32-backed custom dtypes by subclassing a new Pandas dtype: `pd.Float32Dtype`. This strongly parallels our implementation of int32-backed custom dtypes, and should  allow us to better maintain our code with changes to Pandas internals.

After the change:

```
In [1]: x = rs.DataSeries(np.linspace(0, 1, 1000000), dtype=np.float32)

In [2]: %timeit x / 100
388 µs ± 4.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [3]: x = rs.DataSeries(np.linspace(0, 1, 1000000), dtype="MTZReal")

In [4]: %timeit x / 100
436 µs ± 1.98 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

```