### PR TITLE
Fix sign of phase shift in DataSet.apply_symop

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -600,7 +600,7 @@ class DataSet(pd.DataFrame):
             dataset[key] = phic * (dataset[key] - np.rad2deg(phase_shifts))
             dataset[key] = utils.canonicalize_phases(dataset[key], deg=True)
         for key in dataset.get_complex_keys():
-            dataset[key] *= np.exp(1j*phase_shifts)
+            dataset[key] *= np.exp(-1j*phase_shifts)
             if symop.det_rot() < 0:
                 dataset[key] = np.conjugate(dataset[key])
         

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -597,8 +597,7 @@ class DataSet(pd.DataFrame):
 
         # Shift phases according to symop
         for key in dataset.get_phase_keys():
-            dataset[key] += np.rad2deg(phase_shifts)
-            dataset[key] *= phic
+            dataset[key] = phic * (dataset[key] - np.rad2deg(phase_shifts))
             dataset[key] = utils.canonicalize_phases(dataset[key], deg=True)
         for key in dataset.get_complex_keys():
             dataset[key] *= np.exp(1j*phase_shifts)

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1093,6 +1093,7 @@ class DataSet(pd.DataFrame):
         
         return self
 
+    @range_indexed
     def expand_to_p1(self):
         """
         Generates all symmetrically equivalent reflections. The spacegroup 
@@ -1116,7 +1117,6 @@ class DataSet(pd.DataFrame):
         # Apply each symop and drop duplicates with higher ISYM
         for isym, op in enumerate(allops, 1):
             ds = self.copy()
-            ds.reset_index(inplace=True)
             ds["M/ISYM"] = isym
             ds["M/ISYM"] = ds["M/ISYM"].astype("M/ISYM")
             p1 = p1.append(ds.hkl_to_observed(m_isym="M/ISYM"))
@@ -1125,7 +1125,6 @@ class DataSet(pd.DataFrame):
         # Restrict to p1 ASU
         p1.spacegroup = gemmi.SpaceGroup(1)
         p1 = p1.loc[in_asu(p1.get_hkls(), spacegroup=p1.spacegroup)]
-        p1.set_index(["H", "K", "L"], inplace=True)
 
         return p1
 

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1162,7 +1162,7 @@ class DataSet(pd.DataFrame):
 
         return self
 
-    def to_reciprocalgrid(self, key, gridsize, anomalous=False):
+    def to_reciprocalgrid(self, key, gridsize):
         """
         Set up reciprocal grid with values from column, ``key``, indexed by
         Miller indices. A 3D numpy array will be initialized with the
@@ -1173,8 +1173,6 @@ class DataSet(pd.DataFrame):
         -----
         - The data being arranged on a reciprocal grid must be compatible
           with a numpy datatype.
-        - The key specified with ``anomalous=True`` should correspond to the 
-          column label after calling ``stack_anomalous()``.
         
         Parameters
         ----------
@@ -1182,24 +1180,21 @@ class DataSet(pd.DataFrame):
             Column label for value to arrange on reciprocal grid
         gridsize : array-like (len==3)
             Dimensions for 3D reciprocal grid.
-        anomalous : bool
-            Whether to expand the P1 Friedel+ ASU to the Friedel- reflections. 
-            If False, the Friedel+ ASU will be used to complete the P1 unit cell. 
-            If True, the Friedel- reflections should be present in a two-column 
-            anomalous format. 
 
         Returns
         -------
         numpy.ndarray
         """
+        # Set up P1 unit cell
         p1 = self.expand_to_p1()
-        if anomalous:
-            p1 = p1.stack_anomalous()
-        else:
-            p1 = p1.expand_anomalous()
-        p1.sort_index(inplace=True)
+        p1 = p1.expand_anomalous()
+
+        # Get data and indices
         data = p1[key].to_numpy()
         H = p1.get_hkls()
+
+        # Populate grid
         grid = np.zeros(gridsize, dtype=data.dtype)
         grid[H[:, 0], H[:, 1], H[:, 2]] = data
+
         return grid

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -495,14 +495,14 @@ def test_apply_symop_roundtrip(mtz_by_spacegroup):
     dataset = rs.read_mtz(mtz_by_spacegroup)
     for op in dataset.spacegroup.operations():
         applied = dataset.apply_symop(op)
-        back = applied.hkl_to_asu()
+        back = applied.apply_symop(op.inverse())
 
         assert np.array_equal(back.FMODEL.to_numpy(), dataset.FMODEL.to_numpy())
         assert np.array_equal(back.get_hkls(), dataset.get_hkls())
 
         original = rs.utils.to_structurefactor(dataset.FMODEL, dataset.PHIFMODEL)
         back = rs.utils.to_structurefactor(back.FMODEL, back.PHIFMODEL)
-        assert np.isclose(original, back, rtol=1e-3).all()
+        assert np.isclose(original, back).all()
 
 
 @pytest.mark.parametrize("inplace", [True, False])

--- a/tests/test_dataset_grid.py
+++ b/tests/test_dataset_grid.py
@@ -3,7 +3,7 @@ import numpy as np
 import gemmi
 import reciprocalspaceship as rs
 
-@pytest.mark.parametrize("sample_rate", [1, 2, 3])
+@pytest.mark.parametrize("sample_rate", [2.5, 3, 5])
 @pytest.mark.parametrize("p1", [True, False])
 def test_to_reciprocalgrid_complex(mtz_by_spacegroup, sample_rate, p1):
     """
@@ -16,7 +16,7 @@ def test_to_reciprocalgrid_complex(mtz_by_spacegroup, sample_rate, p1):
     gemmimtz = dataset.to_gemmi()
 
     # Note: Use P1 data to determine proper gridsize    
-    testp1 = dataset.expand_to_p1()
+    testp1 = dataset.expand_to_p1().sort_index()
     testp1.spacegroup = dataset.spacegroup
     gridsize = testp1.to_gemmi().get_size_for_hkl(sample_rate=sample_rate)
 
@@ -24,9 +24,9 @@ def test_to_reciprocalgrid_complex(mtz_by_spacegroup, sample_rate, p1):
     expected = np.array(gemmigrid)
     dataset["sf"] = dataset.to_structurefactor("FMODEL", "PHIFMODEL")
     result = dataset.to_reciprocalgrid("sf", gridsize)
-    assert np.allclose(result, expected, rtol=1e-4)
+    assert np.allclose(result, expected, atol=1e-4)
 
-@pytest.mark.parametrize("sample_rate", [1, 2, 3])
+@pytest.mark.parametrize("sample_rate", [2.5, 3, 5])
 @pytest.mark.parametrize("p1", [True, False])
 def test_to_reciprocalgrid_float(mtz_by_spacegroup, sample_rate, p1):
     """

--- a/tests/test_dataset_grid.py
+++ b/tests/test_dataset_grid.py
@@ -24,7 +24,7 @@ def test_to_reciprocalgrid_complex(mtz_by_spacegroup, sample_rate, p1):
     expected = np.array(gemmigrid)
     dataset["sf"] = dataset.to_structurefactor("FMODEL", "PHIFMODEL")
     result = dataset.to_reciprocalgrid("sf", gridsize)
-    assert np.allclose(result, expected, atol=1e-4)
+    assert np.allclose(result, expected, rtol=1e-4)
 
 @pytest.mark.parametrize("sample_rate", [2.5, 3, 5])
 @pytest.mark.parametrize("p1", [True, False])

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -156,7 +156,8 @@ def test_expand_anomalous(data_fmodel_P1):
         gemmi.Op("x-1/3,y+2/3,z-23/24"),
     ],
 )
-def test_apply_symop_mapshift(data_fmodel, op):
+@pytest.mark.parametrize("use_complex", [True, False])
+def test_apply_symop_mapshift(data_fmodel, op, use_complex):
     """
     Compare the results of DataSet.apply_symop() to the structure factors
     corresponding to a map that was shifted in real space
@@ -166,8 +167,13 @@ def test_apply_symop_mapshift(data_fmodel, op):
     tran = (np.array(gridsize) * np.array(op.tran) / op.DEN).astype(int)
 
     # Apply symop
-    result = data_fmodel.apply_symop(op)
-    result["result"] = result.to_structurefactor("FMODEL", "PHIFMODEL")
+    if use_complex:
+        result = data_fmodel
+        result["result"] = result.to_structurefactor("FMODEL", "PHIFMODEL")
+        result = result.apply_symop(op)
+    else:
+        result = data_fmodel.apply_symop(op)
+        result["result"] = result.to_structurefactor("FMODEL", "PHIFMODEL")
 
     # Compute and shift map
     ds["sf"] = ds.to_structurefactor("FMODEL", "PHIFMODEL")

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -123,10 +123,13 @@ def test_expand_anomalous(data_fmodel_P1):
     gemmi.Op("x,y+1/4,z-1/4"),
     gemmi.Op("x-3/4,y+1/4,z-1/4"),
     gemmi.Op("x-3/4,y+1/4,z-3/4"),
-    gemmi.Op("x-3/4,y+3/4,z-3/4"),    
-]) 
+    gemmi.Op("x-3/4,y+3/4,z-3/4"),
+])
 def test_apply_symop_mapshift(data_fmodel, op):
-
+    """
+    Compare the results of DataSet.apply_symop() to the structure factors
+    corresponding to a map that was shifted in real space
+    """
     ds = data_fmodel
     gridsize = (32, 32, 32)
     tran = (np.array(gridsize) * np.array(op.tran) / op.DEN).astype(int)

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -59,20 +59,24 @@ def test_hkl_to_asu(mtz_by_spacegroup, inplace, reset_index, anomalous):
         assert id(yasu) != id(y)
 
 
-def test_expand_to_p1(mtz_by_spacegroup):
+@pytest.mark.parametrize("use_complex", [True, False])
+def test_expand_to_p1(mtz_by_spacegroup, use_complex):
     """Test DataSet.expand_to_p1() for common spacegroups"""
     x = rs.read_mtz(mtz_by_spacegroup)
-
-    expected = rs.read_mtz(mtz_by_spacegroup[:-4] + "_p1.mtz")
-    expected.sort_index(inplace=True)
+    x["sf"] = x.to_structurefactor("FMODEL", "PHIFMODEL")
     result = x.expand_to_p1()
     result.sort_index(inplace=True)
+    expected = rs.read_mtz(mtz_by_spacegroup[:-4] + "_p1.mtz")
+    expected.sort_index(inplace=True)
 
+    if use_complex:
+        result_sf = result["sf"].to_numpy()
+    else:
+        result_sf = result.to_structurefactor("FMODEL", "PHIFMODEL")        
     expected_sf = expected.to_structurefactor("FMODEL", "PHIFMODEL")
-    result_sf = result.to_structurefactor("FMODEL", "PHIFMODEL")
 
     assert_index_equal(result.index, expected.index)
-    assert np.allclose(result_sf.to_numpy(), expected_sf.to_numpy(), rtol=1e-4)
+    assert np.allclose(result_sf, expected_sf.to_numpy(), rtol=1e-4)
 
 
 def test_expand_to_p1_with_p1(mtz_by_spacegroup):

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -75,7 +75,7 @@ def test_expand_to_p1(mtz_by_spacegroup):
     assert np.allclose(result_sf.to_numpy(), expected_sf.to_numpy(), rtol=1e-4)
 
 
-def test_expand_to_p1(mtz_by_spacegroup):
+def test_expand_to_p1_with_p1(mtz_by_spacegroup):
     """DataSet.expand_to_p1() should not affect P1 data"""
     expected = rs.read_mtz(mtz_by_spacegroup[:-4] + "_p1.mtz")
     result = expected.expand_to_p1()

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -157,22 +157,22 @@ def test_expand_anomalous(data_fmodel_P1):
     ],
 )
 @pytest.mark.parametrize("use_complex", [True, False])
-def test_apply_symop_mapshift(data_fmodel, op, use_complex):
+def test_apply_symop_mapshift(data_fmodel_P1, op, use_complex):
     """
     Compare the results of DataSet.apply_symop() to the structure factors
     corresponding to a map that was shifted in real space
     """
-    ds = data_fmodel
+    ds = data_fmodel_P1.copy()
     gridsize = (48, 48, 48)
     tran = (np.array(gridsize) * np.array(op.tran) / op.DEN).astype(int)
 
     # Apply symop
     if use_complex:
-        result = data_fmodel
+        result = data_fmodel_P1
         result["result"] = result.to_structurefactor("FMODEL", "PHIFMODEL")
         result = result.apply_symop(op)
     else:
-        result = data_fmodel.apply_symop(op)
+        result = data_fmodel_P1.apply_symop(op)
         result["result"] = result.to_structurefactor("FMODEL", "PHIFMODEL")
 
     # Compute and shift map

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -99,6 +99,13 @@ def test_expand_to_p1_unmerged(data_unmerged):
         result = data_unmerged.expand_to_p1()
 
 
+def test_expand_to_p1_outofasu(data_fmodel):
+    """Test DataSet.expand_to_p1() raises ValueError with data out of ASU"""
+    test = data_fmodel.apply_symop("-x,-y,-z")
+    with pytest.raises(ValueError):
+        result = test.expand_to_p1()
+
+
 def test_expand_anomalous(data_fmodel_P1):
     """
     Test DataSet.expand_anomalous() doubles reflections and applies


### PR DESCRIPTION
Based on visual inspection of maps, it appeared that `DataSet.apply_symop()` was applying phase shifts in the opposite direction of the specified symmetry operation. This PR changes the sign for how phase shifts are applied, and updates the relevant test.