### PR TITLE
Add complex structure factor support to DataSet.hkl_to_asu()

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1000,6 +1000,11 @@ class DataSet(pd.DataFrame):
         for k in dataset.get_phase_keys():
             dataset[k] = phi_coeff[inverse] * (dataset[k] + phi_shift[inverse])
         dataset.canonicalize_phases(inplace=True)
+        # GH#15: Handle complex structure factors
+        for k in dataset.get_complex_keys():
+            self[k] *= np.exp(1j*np.deg2rad(phi_shift[inverse]))
+            friedel_mask = phi_coeff[inverse] != 1
+            self.loc[friedel_mask, k] = np.conjugate(self.loc[friedel_mask, k])
         
         # GH#3: if PARTIAL column exists, use it to construct M/ISYM
         if "PARTIAL" in dataset.columns:
@@ -1085,6 +1090,7 @@ class DataSet(pd.DataFrame):
         # Apply phase shift
         for k in self.get_phase_keys():
             self[k] = phi_coeff[inverse] * (self[k] + phi_shift[inverse])
+        # GH#15: Handle complex structure factors
         for k in self.get_complex_keys():
             self[k] *= np.exp(1j*np.deg2rad(phi_shift[inverse]))
             friedel_mask = phi_coeff[inverse] != 1

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -61,7 +61,8 @@ def test_hkl_to_asu(mtz_by_spacegroup, inplace, reset_index, anomalous):
     assert np.allclose(result["sf"], expected.loc[result.index, "sf"])
 
 
-def test_hklmapping_roundtrip_phase(mtz_by_spacegroup):
+@pytest.mark.parametrize("anomalous", [True, False])
+def test_hklmapping_roundtrip_phase(mtz_by_spacegroup, anomalous):
     """
     Test roundtrip of DataSet.hkl_to_asu() and DataSet.hkl_to_observed() preserve
     phases
@@ -71,7 +72,7 @@ def test_hklmapping_roundtrip_phase(mtz_by_spacegroup):
     expected["sf"] = expected.to_structurefactor("FMODEL", "PHIFMODEL")
 
     # Roundtrip
-    temp = expected.hkl_to_asu()
+    temp = expected.hkl_to_asu(anomalous=anomalous)
     result = temp.hkl_to_observed()
 
     # Check indices

--- a/tests/test_dataset_symops.py
+++ b/tests/test_dataset_symops.py
@@ -61,8 +61,7 @@ def test_hkl_to_asu(mtz_by_spacegroup, inplace, reset_index, anomalous):
     assert np.allclose(result["sf"], expected.loc[result.index, "sf"])
 
 
-@pytest.mark.parametrize("anomalous", [True, False])
-def test_hklmapping_roundtrip_phase(mtz_by_spacegroup, anomalous):
+def test_hklmapping_roundtrip_phase(mtz_by_spacegroup):
     """
     Test roundtrip of DataSet.hkl_to_asu() and DataSet.hkl_to_observed() preserve
     phases
@@ -70,9 +69,10 @@ def test_hklmapping_roundtrip_phase(mtz_by_spacegroup, anomalous):
     ref = rs.read_mtz(mtz_by_spacegroup)
     expected = rs.read_mtz(mtz_by_spacegroup[:-4] + "_p1.mtz")
     expected["sf"] = expected.to_structurefactor("FMODEL", "PHIFMODEL")
-
+    expected.spacegroup = ref.spacegroup
+    
     # Roundtrip
-    temp = expected.hkl_to_asu(anomalous=anomalous)
+    temp = expected.hkl_to_asu()
     result = temp.hkl_to_observed()
 
     # Check indices


### PR DESCRIPTION
Fixes #15 by adding support for complex structure factors to `DataSet.hkl_to_asu()`. This method, as well as `DataSet.hkl_to_observed()` and `DataSet.apply_symop()` now support applying phase shifts complex structure factors as well to `PhaseDtype` columns. 

This method is tested by confirming that:
- `hkl_to_asu()` moves "P1 data" to the reciprocal ASU while correctly shifting the phase for the 63 spacegroups in our fmodel-based test set
- roundtrips of `hkl_to_asu()` and `hkl_to_observed()` preserve the phase of all reflections for the 63 spacegroups in our fmodel-based test set