### PR TITLE
Add documentation for rs.utils functions to Developers section

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,8 @@ extensions = [
     'nbsphinx',
     "sphinx.ext.linkcode",
     "sphinx_panels",
-    "sphinxcontrib.autoprogram"
+    "sphinxcontrib.autoprogram",
+    "autodocsumm",
 ]
 
 napoleon_google_docstring = False

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -17,6 +17,7 @@ help you follow our best practices when contributing to the library.
    :maxdepth: 1
 
    contributing
+   utilities
    testing
    documentation
 

--- a/docs/developers/utilities.rst
+++ b/docs/developers/utilities.rst
@@ -1,0 +1,17 @@
+.. _utilities:
+
+Utility Functions
+=================
+
+``rs.utils`` contains symmetry/spacegroup-related operations that serve as the foundation for much
+of the crystallographic support provided by ``reciprocalspaceship``. These methods are not
+considered to be user-facing, but they are documented here because they may be useful for
+composing new methods or algorithms.
+
+.. Note::
+   In most cases, these functions are written to operate on and return ``NumPy`` arrays. This was
+   chosen to ensure that these methods are performant, and can be largely independent of any
+   interface decisions related to ``rs.DataSet`` or ``pandas``.
+
+.. automodule:: reciprocalspaceship.utils
+   :autosummary:

--- a/reciprocalspaceship/utils/__init__.py
+++ b/reciprocalspaceship/utils/__init__.py
@@ -1,3 +1,28 @@
+# Public API for `reciprocalspaceship.utils`
+__all__ = [
+    "canonicalize_phases",
+    "get_phase_restrictions",
+    "to_structurefactor",
+    "from_structurefactor",
+    "compute_structurefactor_multiplicity",
+    "is_centric",
+    "is_absent",
+    "apply_to_hkl",
+    "phase_shift",
+    "add_rfree",
+    "copy_rfree",
+    "compute_dHKL",
+    "generate_reciprocal_cell",
+    "hkl_to_asu",
+    "hkl_to_observed",
+    "in_asu",
+    "generate_reciprocal_asu",
+    "bin_by_percentile",
+    "ev2angstroms",
+    "angstroms2ev",
+    "compute_redundancy",
+]
+
 from .phases import canonicalize_phases, get_phase_restrictions
 from .structurefactors import (to_structurefactor,
                                from_structurefactor,

--- a/reciprocalspaceship/utils/rfree.py
+++ b/reciprocalspaceship/utils/rfree.py
@@ -18,8 +18,8 @@ def add_rfree(dataset, fraction=0.05, bins=20, inplace=False):
         Number of resolution bins to divide the free reflections over. (the default is 20)
     inplace : bool, optional
 
-    Returns:
-    --------
+    Returns
+    -------
     result : rs.DataSet
 
     """
@@ -49,6 +49,7 @@ def add_rfree(dataset, fraction=0.05, bins=20, inplace=False):
 def copy_rfree(dataset, dataset_with_rfree, inplace=False):
     """
     Copy the rfree flag from one dataset object to another.
+
     Parameters
     ----------
     dataset : rs.DataSet
@@ -56,8 +57,10 @@ def copy_rfree(dataset, dataset_with_rfree, inplace=False):
     dataset_with_rfree : rs.DataSet
         A dataset with desired r-free flags.
     inplace : bool, optional
+        Whether to operate in place or return a copy
 
-    Returns:
+    Returns
+    -------
     result : rs.DataSet
     """
     if not inplace:

--- a/reciprocalspaceship/utils/structurefactors.py
+++ b/reciprocalspaceship/utils/structurefactors.py
@@ -50,6 +50,8 @@ def from_structurefactor(sfs):
 
 def compute_structurefactor_multiplicity(H, sg, include_centering=True):
     """
+    Compute the multiplicity of each reflection in ``H``.
+
     Parameters
     ----------
     H : array

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ setup(
             "sphinx-panels",
             "sphinxcontrib-autoprogram",
             "jupyter",
-
+            "autodocsumm",
+            
             # example notebooks
             "tqdm",
             "matplotlib",


### PR DESCRIPTION
There are useful functions in `rs.utils` that serve as the foundation for our crystallographic support in this library. These functions could be useful to anyone interested in writing/contributing new methods to incorporate into `rs`, so they should be documented. 

This PR adds a page to the "For Developers" section of the documentation site that describes each of the functions in `rs.utils` based on the relevant docstrings. Only the "public API" of `rs.utils` -- as specified by the `__all__` list in `reciprocalspaceship.utils.__init__.py` -- will appear on the site.