### PR TITLE
Add rs.read_pickle() helper method

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -30,7 +30,8 @@ These two objects can be thought of as crystallographically-aware versions of ``
 Input/Output
 ------------
 
-Supported crystallographic file formats for data I/O. Write functions for reflection file formats are available as methods of ``rs.DataSet`` objects.
+Supported crystallographic file formats for data I/O. Although they are not listed below, write functions for reflection file formats
+are available as methods of ``rs.DataSet`` objects.
 
 .. currentmodule:: reciprocalspaceship
 .. autosummary::
@@ -39,6 +40,7 @@ Supported crystallographic file formats for data I/O. Write functions for reflec
 
    ~reciprocalspaceship.read_mtz
    ~reciprocalspaceship.read_csv
+   ~reciprocalspaceship.read_pickle
    ~reciprocalspaceship.read_precognition
    ~reciprocalspaceship.read_crystfel
    ~reciprocalspaceship.io.write_ccp4_map

--- a/reciprocalspaceship/__init__.py
+++ b/reciprocalspaceship/__init__.py
@@ -8,7 +8,13 @@ __version__ = getVersionNumber()
 # Top-Level API
 from .dataset import DataSet
 from .dataseries import DataSeries
-from .io import read_mtz, read_precognition, read_csv, read_crystfel
+from .io import (
+    read_mtz,
+    read_precognition,
+    read_csv,
+    read_crystfel,
+    read_pickle
+)
 from .dtypes import summarize_mtz_dtypes
 from .concat import concat
 

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -347,6 +347,24 @@ class DataSet(pd.DataFrame):
         from reciprocalspaceship import io
         return io.to_gemmi(self, skip_problem_mtztypes)
 
+    def to_pickle(self, path, *args, **kwargs):
+        """
+        Pickle object to file.
+
+        For additional documentation on accepted arguments, see the                                                                                                                                     
+        `Pandas DataFrame.to_pickle() API <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_pickle.html>`_.
+
+        Parameters
+        ----------
+        path : str
+            File path where the pickled object will be stored.
+
+        See Also
+        --------
+        read_pickle() : Load pickled reciprocalspaceship object from file.
+        """
+        return super().to_pickle(path, *args, **kwargs)
+    
     def to_structurefactor(self, sf_key, phase_key):
         """
         Convert structure factor amplitudes and phases to complex structure

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -351,7 +351,7 @@ class DataSet(pd.DataFrame):
         """
         Pickle object to file.
 
-        For additional documentation on accepted arguments, see the                                                                                                                                     
+        This can be useful for saving non-MTZ compatible data files for future use. For additional documentation on accepted arguments, see the
         `Pandas DataFrame.to_pickle() API <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_pickle.html>`_.
 
         Parameters

--- a/reciprocalspaceship/io/__init__.py
+++ b/reciprocalspaceship/io/__init__.py
@@ -10,3 +10,4 @@ from .precognition import (
 from .crystfel import (read_crystfel)
 from .ccp4map import write_ccp4_map
 from .csv import read_csv
+from .pickle import read_pickle

--- a/reciprocalspaceship/io/pickle.py
+++ b/reciprocalspaceship/io/pickle.py
@@ -13,6 +13,10 @@ def read_pickle(filepath_or_buffer):
     Returns
     -------
     unpickled : same type as object stored in file
+
+    See Also
+    --------
+    DataSet.to_pickle : Pickle object to file
     """
     unpickled = pd.read_pickle(filepath_or_buffer)
 

--- a/reciprocalspaceship/io/pickle.py
+++ b/reciprocalspaceship/io/pickle.py
@@ -1,8 +1,9 @@
 import pandas as pd
+from reciprocalspaceship import DataSeries
 
 def read_pickle(filepath_or_buffer):
     """
-    Load pickled DataSet object from file.
+    Load pickled reciprocalspaceship object from file.
 
     Parameters
     ----------
@@ -13,11 +14,15 @@ def read_pickle(filepath_or_buffer):
     -------
     unpickled : same type as object stored in file
     """
-    dataset = pd.read_pickle(filepath_or_buffer)
+    unpickled = pd.read_pickle(filepath_or_buffer)
+
+    # Ensure DataSeries objects are not promoted to DataSet
+    if isinstance(unpickled, DataSeries):
+        return unpickled
 
     # Clean up datatypes for index
-    index_labels = dataset.index.names
-    dataset.reset_index(inplace=True)
-    dataset.set_index(index_labels, inplace=True)
+    index_labels = unpickled.index.names
+    unpickled = unpickled.reset_index()
+    unpickled = unpickled.set_index(index_labels)
 
-    return dataset
+    return unpickled

--- a/reciprocalspaceship/io/pickle.py
+++ b/reciprocalspaceship/io/pickle.py
@@ -13,4 +13,11 @@ def read_pickle(filepath_or_buffer):
     -------
     unpickled : same type as object stored in file
     """
-    return pd.read_pickle(filepath_or_buffer)
+    dataset = pd.read_pickle(filepath_or_buffer)
+
+    # Clean up datatypes for index
+    index_labels = dataset.index.names
+    dataset.reset_index(inplace=True)
+    dataset.set_index(index_labels, inplace=True)
+
+    return dataset

--- a/reciprocalspaceship/io/pickle.py
+++ b/reciprocalspaceship/io/pickle.py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+def read_pickle(filepath_or_buffer):
+    """
+    Load pickled DataSet object from file.
+
+    Parameters
+    ----------
+    filepath_or_buffer : str, path object or file-like object
+        Pickled object to be read
+
+    Returns
+    -------
+    unpickled : same type as object stored in file
+    """
+    return pd.read_pickle(filepath_or_buffer)

--- a/tests/io/test_pickle.py
+++ b/tests/io/test_pickle.py
@@ -1,0 +1,42 @@
+import pytest
+import tempfile
+import gemmi
+import reciprocalspaceship as rs
+from pandas.testing import assert_frame_equal
+
+@pytest.mark.parametrize("spacegroup", [None, 1, 4, 19])
+@pytest.mark.parametrize("cell", [
+    None,
+    gemmi.UnitCell(1, 1, 1, 90, 90, 90),
+    gemmi.UnitCell(3, 4, 5, 90, 90, 120)
+])
+@pytest.mark.parametrize("merged", [True, False])
+def test_pickle_roundtrip(data_fmodel, spacegroup, cell, merged):
+    """Test roundtrip of DataSet.to_pickle() and rs.read_pickle()"""
+    pklfile = tempfile.NamedTemporaryFile(suffix=".pkl")
+
+    # Setup expected result DataSet
+    expected = data_fmodel
+    expected.spacegroup = spacegroup
+    expected.cell = cell
+    expected.merged = merged
+    
+    # Roundtrip
+    expected.to_pickle(pklfile.name)
+    result = rs.read_pickle(pklfile.name)
+    pklfile.close()
+
+    assert isinstance(result, rs.DataSet)
+    assert_frame_equal(result, expected)
+    assert result._index_dtypes == expected._index_dtypes
+    assert result.merged == merged
+    
+    if spacegroup:
+        assert result.spacegroup.xhm() == expected.spacegroup.xhm()
+    else:
+        assert result.spacegroup is None
+
+    if cell:
+        assert result.cell.parameters == expected.cell.parameters
+    else:
+        assert result.cell is None

--- a/tests/io/test_pickle.py
+++ b/tests/io/test_pickle.py
@@ -2,7 +2,7 @@ import pytest
 import tempfile
 import gemmi
 import reciprocalspaceship as rs
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 @pytest.mark.parametrize("spacegroup", [None, 1, 4, 19])
 @pytest.mark.parametrize("cell", [
@@ -11,7 +11,7 @@ from pandas.testing import assert_frame_equal
     gemmi.UnitCell(3, 4, 5, 90, 90, 120)
 ])
 @pytest.mark.parametrize("merged", [True, False])
-def test_pickle_roundtrip(data_fmodel, spacegroup, cell, merged):
+def test_pickle_roundtrip_dataset(data_fmodel, spacegroup, cell, merged):
     """Test roundtrip of DataSet.to_pickle() and rs.read_pickle()"""
     pklfile = tempfile.NamedTemporaryFile(suffix=".pkl")
 
@@ -40,3 +40,19 @@ def test_pickle_roundtrip(data_fmodel, spacegroup, cell, merged):
         assert result.cell.parameters == expected.cell.parameters
     else:
         assert result.cell is None
+
+@pytest.mark.parametrize("label", ["FMODEL", "PHIFMODEL"])
+def test_pickle_roundtrip_dataseries(data_fmodel, label):
+    """Test roundtrip of DataSeries.to_pickle() and rs.read_pickle()"""
+    pklfile = tempfile.NamedTemporaryFile(suffix=".pkl")
+
+    # Setup expected result DataSeries
+    expected = data_fmodel[label]
+    
+    # Roundtrip
+    expected.to_pickle(pklfile.name)
+    result = rs.read_pickle(pklfile.name)
+    pklfile.close()
+
+    assert isinstance(result, rs.DataSeries)
+    assert_series_equal(result, expected, check_index_type=False)


### PR DESCRIPTION
This PR adds a `read_pickle()` method to the `rs` namespace in order to easily allow roundtrip operations with `DataSet.to_pickle()` and `rs.read_pickle()`.

This method is particularly useful for storing non-MTZ compatible dtypes in a way that can be written to a file for later use in `rs`.