### PR TITLE
Update reciprocalspaceship to support pandas 1.3.0

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -235,7 +235,7 @@ class DataSet(pd.DataFrame):
             else:
                 raise ValueError(f"{key} is not an instance of type str, np.ndarray, pd.Index, pd.Series, or list")
             
-        return super().set_index(keys, drop, append, inplace, verify_integrity)
+        return super().set_index(keys, drop=drop, append=append, inplace=inplace, verify_integrity=verify_integrity)
 
     def reset_index(self, level=None, drop=False, inplace=False, col_level=0, col_fill=''):
         """
@@ -289,11 +289,11 @@ class DataSet(pd.DataFrame):
             return dataset
         
         if inplace:
-            super().reset_index(level, drop, inplace, col_level, col_fill)
+            super().reset_index(level, drop=drop, inplace=inplace, col_level=col_level, col_fill=col_fill)
             _handle_cached_dtypes(self, columns, drop)
             return
         else:
-            dataset = super().reset_index(level, drop, inplace, col_level, col_fill)
+            dataset = super().reset_index(level, drop=drop, inplace=inplace, col_level=col_level, col_fill=col_fill)
             dataset._index_dtypes = dataset._index_dtypes.copy()
             dataset = _handle_cached_dtypes(dataset, columns, drop)
             return dataset

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     python_requires=">3.6",
     install_requires=[
         "gemmi >= 0.4.2",
-        "pandas >= 1.2.0, < 1.3",
+        "pandas >= 1.2.0, <= 1.3.0",
         "numpy",
         "scipy",
         "ipython",

--- a/tests/algorithms/test_merge.py
+++ b/tests/algorithms/test_merge.py
@@ -33,7 +33,7 @@ def test_merge(hewl_unmerged, hewl_merged, keys, sort):
     assert merged.merged
     assert merged.spacegroup.xhm() == hewl_merged.spacegroup.xhm()
     assert merged.cell.a == hewl_merged.cell.a
-    assert merged.index.is_lexsorted() == sort
+    assert merged.index.is_monotonic_increasing == sort
     
     # Note: AIMLESS zero-fills empty observations, whereas we use NaNs
     for key in merged.columns:

--- a/tests/algorithms/test_scale_merged_intensities.py
+++ b/tests/algorithms/test_scale_merged_intensities.py
@@ -199,17 +199,17 @@ def test_fw_posterior_quad(ref_method, data_fw_cctbx, data_fw_mcmc):
     """
     if ref_method == 'cctbx':
         I,SigI,Sigma,J,SigJ,F,SigF,Centric = data_fw_cctbx.to_numpy(np.float64).T
-        Centric = Centric.astype(np.bool)
+        Centric = Centric.astype(bool)
         rtol = 0.06
         rs_J,rs_SigJ,rs_F,rs_SigF = _french_wilson_posterior_quad(I, SigI, Sigma, Centric)
     elif ref_method == 'mcmc':
         I,SigI,Sigma,J,SigJ,F,SigF,Centric = data_fw_mcmc.to_numpy(np.float64).T
-        Centric = Centric.astype(np.bool)
+        Centric = Centric.astype(bool)
         rtol = 0.025
         rs_J,rs_SigJ,rs_F,rs_SigF = _french_wilson_posterior_quad(I, SigI, Sigma, Centric)
     elif ref_method == 'mcmc vs cctbx':
         I,SigI,Sigma,J,SigJ,F,SigF,Centric = data_fw_mcmc.to_numpy(np.float64).T
-        Centric = Centric.astype(np.bool)
+        Centric = Centric.astype(bool)
         _,_,_,rs_J,rs_SigJ,rs_F,rs_SigF,_ = data_fw_cctbx.to_numpy(np.float64).T
         rtol = 0.06
 

--- a/tests/dtypes/conftest.py
+++ b/tests/dtypes/conftest.py
@@ -156,43 +156,17 @@ def all_boolean_reductions(request):
     """
     return request.param
 
-array = {
-    # Integer dtypes
-    "HKL": rs.dtypes.hklindex.HKLIndexArray,
-    "MTZInt": rs.dtypes.mtzint.MTZIntArray,
-    "Batch": rs.dtypes.batch.BatchArray,
-    "M/ISYM": rs.dtypes.m_isym.M_IsymArray,
-
-    # Float32 dtypes
-    "Intensity": rs.dtypes.intensity.IntensityArray,
-    "SFAmplitude": rs.dtypes.structurefactor.StructureFactorAmplitudeArray,
-    "AnomalousDifference": rs.dtypes.anomalousdifference.AnomalousDifferenceArray,
-    "Stddev": rs.dtypes.stddev.StandardDeviationArray,
-    "FriedelSFAmplitude": rs.dtypes.structurefactor.FriedelStructureFactorAmplitudeArray,
-    "StddevFriedelSF": rs.dtypes.stddev.StandardDeviationFriedelSFArray,
-    "FriedelIntensity": rs.dtypes.intensity.FriedelIntensityArray,
-    "StddevFriedelI": rs.dtypes.stddev.StandardDeviationFriedelIArray,
-    "NormalizedSFAmplitude": rs.dtypes.structurefactor.NormalizedStructureFactorAmplitudeArray,
-    "Phase": rs.dtypes.phase.PhaseArray,
-    "Weight": rs.dtypes.weight.WeightArray,
-    "HendricksonLattman": rs.dtypes.phase.HendricksonLattmanArray,
-    "MTZReal": rs.dtypes.mtzreal.MTZRealArray
-}
-
 @pytest.fixture
 def data_int(dtype_ints):
-    return array[dtype_ints[0].name]._from_sequence(np.arange(0, 100),
-                                                    dtype=dtype_ints[0]())
+    return pd.array(np.arange(0, 100), dtype=dtype_ints[0]())
 
 @pytest.fixture
 def data_float(dtype_floats):
-    return array[dtype_floats[0].name]._from_sequence(np.arange(0, 100),
-                                                      dtype=dtype_floats[0]())
+    return pd.array(np.arange(0, 100), dtype=dtype_floats[0]())
 
 @pytest.fixture
 def data_all(dtype_all):
-    return array[dtype_all[0].name]._from_sequence(np.arange(0, 100),
-                                                   dtype=dtype_all[0]())
+    return pd.array(np.arange(0, 100), dtype=dtype_all[0]())
 
 @pytest.fixture(params=[None, lambda x: x])
 def sort_by_key(request):

--- a/tests/dtypes/test_floats_pandas.py
+++ b/tests/dtypes/test_floats_pandas.py
@@ -9,22 +9,6 @@ import reciprocalspaceship as rs
 import pandas as pd
 from pandas.tests.extension import base
 
-array = {
-    "Intensity": rs.dtypes.intensity.IntensityArray,
-    "SFAmplitude": rs.dtypes.structurefactor.StructureFactorAmplitudeArray,
-    "AnomalousDifference": rs.dtypes.anomalousdifference.AnomalousDifferenceArray,
-    "Stddev": rs.dtypes.stddev.StandardDeviationArray,
-    "FriedelSFAmplitude": rs.dtypes.structurefactor.FriedelStructureFactorAmplitudeArray,
-    "StddevFriedelSF": rs.dtypes.stddev.StandardDeviationFriedelSFArray,
-    "FriedelIntensity": rs.dtypes.intensity.FriedelIntensityArray,
-    "StddevFriedelI": rs.dtypes.stddev.StandardDeviationFriedelIArray,
-    "NormalizedSFAmplitude": rs.dtypes.structurefactor.NormalizedStructureFactorAmplitudeArray,
-    "Phase": rs.dtypes.phase.PhaseArray,
-    "Weight": rs.dtypes.weight.WeightArray,
-    "HendricksonLattman": rs.dtypes.phase.HendricksonLattmanArray,
-    "MTZReal": rs.dtypes.mtzreal.MTZRealArray
-}
-
 @pytest.fixture(
     params=[
         rs.IntensityDtype,
@@ -47,23 +31,23 @@ def dtype(request):
 
 @pytest.fixture
 def data(dtype):
-    return array[dtype.name]._from_sequence(np.arange(0, 100), dtype=dtype)
+    return pd.array(np.arange(0, 100), dtype=dtype)
 
 @pytest.fixture
 def data_for_twos(dtype):
-    return array[dtype.name]._from_sequence(np.ones(100) * 2, dtype=dtype)
+    return pd.array(np.ones(100) * 2, dtype=dtype)
 
 @pytest.fixture
 def data_missing(dtype):
-    return array[dtype.name]._from_sequence([np.nan, 1.], dtype=dtype)
+    return pd.array([np.nan, 1.], dtype=dtype)
 
 @pytest.fixture
 def data_for_sorting(dtype):
-    return array[dtype.name]._from_sequence([1., 2., 0.], dtype=dtype)
+    return pd.array([1., 2., 0.], dtype=dtype)
 
 @pytest.fixture
 def data_missing_for_sorting(dtype):
-    return array[dtype.name]._from_sequence([1., np.nan, 0.], dtype=dtype)
+    return pd.array([1., np.nan, 0.], dtype=dtype)
 
 @pytest.fixture(params=['data', 'data_missing'])
 def all_data(request, data, data_missing):
@@ -79,7 +63,7 @@ def data_for_grouping(dtype):
     a = 0
     c = 2
     na = np.nan
-    return array[dtype.name]._from_sequence([b, b, na, na, a, a, b, c], dtype=dtype)
+    return pd.array([b, b, na, na, a, a, b, c], dtype=dtype)
 
 class TestCasting(base.BaseCastingTests):
     pass

--- a/tests/dtypes/test_ints_pandas.py
+++ b/tests/dtypes/test_ints_pandas.py
@@ -4,13 +4,6 @@ import pandas as pd
 import reciprocalspaceship as rs
 from pandas.tests.extension import base
 
-array = {
-    "HKL": rs.dtypes.hklindex.HKLIndexArray,
-    "MTZInt": rs.dtypes.mtzint.MTZIntArray,
-    "Batch": rs.dtypes.batch.BatchArray,
-    "M/ISYM": rs.dtypes.m_isym.M_IsymArray
-}
-
 @pytest.fixture(
     params=[
         rs.HKLIndexDtype,
@@ -24,23 +17,23 @@ def dtype(request):
 
 @pytest.fixture
 def data(dtype):
-    return array[dtype.name]._from_sequence(np.arange(0, 100), dtype=dtype)
+    return pd.array(np.arange(0, 100), dtype=dtype)
 
 @pytest.fixture
 def data_for_twos(dtype):
-    return array[dtype.name]._from_sequence(np.ones(100) * 2, dtype=dtype)
+    return pd.array(np.ones(100) * 2, dtype=dtype)
 
 @pytest.fixture
 def data_missing(dtype):
-    return array[dtype.name]._from_sequence([np.nan, 1.], dtype=dtype)
+    return pd.array([np.nan, 1.], dtype=dtype)
 
 @pytest.fixture
 def data_for_sorting(dtype):
-    return array[dtype.name]._from_sequence([1., 2., 0.], dtype=dtype)
+    return pd.array([1., 2., 0.], dtype=dtype)
 
 @pytest.fixture
 def data_missing_for_sorting(dtype):
-    return array[dtype.name]._from_sequence([1., np.nan, 0.], dtype=dtype)
+    return pd.array([1., np.nan, 0.], dtype=dtype)
 
 @pytest.fixture(params=['data', 'data_missing'])
 def all_data(request, data, data_missing):
@@ -56,7 +49,7 @@ def data_for_grouping(dtype):
     a = 0
     c = 2
     na = np.nan
-    return array[dtype.name]._from_sequence([b, b, na, na, a, a, b, c], dtype=dtype)
+    return pd.array([b, b, na, na, a, a, b, c], dtype=dtype)
 
 class TestCasting(base.BaseCastingTests):
     pass

--- a/tests/utils/test_cell.py
+++ b/tests/utils/test_cell.py
@@ -31,7 +31,7 @@ def test_compute_dHKL(dataset_hkl, cell):
     gemmi.UnitCell(291., 423., 315., 90., 100., 90.),
     gemmi.UnitCell(30., 50., 90., 75., 80., 106.),
 ])
-@pytest.mark.parametrize("dtype", [np.float, np.int32, np.int])
+@pytest.mark.parametrize("dtype", [float, np.int32, int])
 def test_generate_reciprocal_cell(cell, dtype):
     """Test rs.utils.generate_reciprocal_cell"""
     dmin = 5.0


### PR DESCRIPTION
This PR updates reciprocalspaceship to support the new release of pandas (v1.3.0):
 - Updated to remove numpy deprecation warnings in test suite
 - Removed pandas deprecation warnings pertaining to `DataSet.set_index()` and `DataSet.reset_index()` keyword arguments
 - Simplified dtype testing by using `pd.array()` to initialize arrays of each dtype