### PR TITLE
Modify Crystfel Stream Parser to Return Pixel Coordinates

### DIFF
--- a/reciprocalspaceship/io/crystfel.py
+++ b/reciprocalspaceship/io/crystfel.py
@@ -124,7 +124,7 @@ def _parse_stream(filename: str) -> dict:
                 #    h    k    l          I   sigma(I)       peak background  fs/px  ss/px panel
                 #  -63   41    9     -41.31      57.45     195.00     170.86  731.0 1350.4 p0
                 crystal_peak_number += 1
-                h, k, l, I, sigmaI, _, _, _, _, _ = [i for i in line.split()]
+                h, k, l, I, sigmaI, peak, background, xdet, ydet, panel = [i for i in line.split()]
                 h, k, l = map(int, [h, k, l])
 
                 # calculate ewald offset and s1
@@ -143,7 +143,9 @@ def _parse_stream(filename: str) -> dict:
                     's1x': s1x,
                     's1y': s1y,
                     's1z': s1z,
-                    'ewald_offset': ewald_offset
+                    'ewald_offset': ewald_offset,
+                    'XDET' : float(xdet),
+                    'YDET' : float(ydet),
                 }
                 if current_event is not None:
                     name = (current_filename, current_event,
@@ -208,14 +210,23 @@ def read_crystfel(streamfile) -> DataSet:
     # BATCH -- B
     # s1{x,y,z} -- R
     # ewald_offset -- R
-    names = [
-        'H', 'K', 'L', 'I', 'sigmaI', 'BATCH', 's1x', 's1y', 's1z',
-        'ewald_offset'
-    ]
-    mtztypes = ["H", "H", "H", "J", "Q", "B", "R", "R", "R", "R"]
+    mtzdtypes = {
+        "H" : "H",
+        "K" : "H",
+        "L" : "H",
+        "I" : "J",
+        "sigmaI" : "Q",
+        "BATCH" : "B",
+        "s1x" : "R",
+        "s1y" : "R",
+        "s1z" : "R",
+        "ewald_offset" : "R",
+        "XDET" : "R",
+        "YDET" : "R",
+    }
     dataset = DataSet()
-    for (k, v), mtztype in zip(df.items(), mtztypes):
-        dataset[k] = v.astype(mtztype)
+    for k, v in df.items():
+        dataset[k] = v.astype(mtzdtypes[k])
     dataset.set_index(['H', 'K', 'L'], inplace=True)
 
     dataset.merged = False  # CrystFEL stream is always unmerged

--- a/reciprocalspaceship/io/crystfel.py
+++ b/reciprocalspaceship/io/crystfel.py
@@ -107,17 +107,11 @@ def _parse_stream(filename: str) -> dict:
             elif is_photon_energy(line):
                 photon_energy = float(line.split()[2])
             elif is_astar(line):
-                astar = np.array(list(map(
-                    float,
-                    line.split()[2:5]))) / 10.  # crystfel's notation uses nm-1
+                astar = np.array(line.split()[2:5], dtype='float32') / 10.  # crystfel's notation uses nm-1
             elif is_bstar(line):
-                bstar = np.array(list(map(
-                    float,
-                    line.split()[2:5]))) / 10.  # crystfel's notation uses nm-1
+                bstar = np.array(line.split()[2:5], dtype='float32') / 10.  # crystfel's notation uses nm-1
             elif is_cstar(line):
-                cstar = np.array(list(map(
-                    float,
-                    line.split()[2:5]))) / 10.  # crystfel's notation uses nm-1
+                cstar = np.array(line.split()[2:5], dtype='float32') / 10.  # crystfel's notation uses nm-1
 
                 # since it's the last line needed to construct Ewald offset,
                 # we'll pre-compute the matrices here

--- a/tests/io/test_crystfel.py
+++ b/tests/io/test_crystfel.py
@@ -32,6 +32,8 @@ class TestCrystFEL(unittest.TestCase):
         self.assertTrue('s1y' in hewl.columns)
         self.assertTrue('s1z' in hewl.columns)
         self.assertTrue('BATCH' in hewl.columns)
+        self.assertTrue('XDET' in hewl.columns)
+        self.assertTrue('YDET' in hewl.columns)
         self.assertIsInstance(hewl, rs.DataSet)
         self.assertIsInstance(hewl["I"], rs.DataSeries)
         self.assertIsInstance(hewl["sigmaI"], rs.DataSeries)


### PR DESCRIPTION
Modify the crystfel stream parser to return columns for the pixel position of spots. These are called "XDET" and "YDET" following the DIALS (and maybe others?) convention. 