### PR TITLE
add support for generators to rs.concat

### DIFF
--- a/reciprocalspaceship/concat.py
+++ b/reciprocalspaceship/concat.py
@@ -1,4 +1,5 @@
 import reciprocalspaceship as rs
+from itertools import tee
 import pandas as pd
 
 def concat(*args, check_isomorphous=True, **kwargs):
@@ -29,9 +30,10 @@ def concat(*args, check_isomorphous=True, **kwargs):
     DataSet.append : Concatenate DataSets
     """
     objs = kwargs.get("objs", args[0])
-    first = objs[0]
+    objs,objs_tee = tee(objs)
+    first = next(objs_tee)
     if check_isomorphous and isinstance(first, rs.DataSet):
-        for obj in objs[1:]:
+        for obj in objs:
             if not first.is_isomorphous(obj):
                 raise ValueError("Provided DataSets are not isomorphous")
         


### PR DESCRIPTION
`rs.concat` does not support generators whereas `pd.concat` does. The reason `rs` does not support them, is that the control flow that checks whether the arguments are isomorphous specifically [indexes the first element in the passed sequence](https://github.com/Hekstra-Lab/reciprocalspaceship/blob/3e66ad04ffeb69eccb277d1afb2ab9c0a4a9defa/reciprocalspaceship/concat.py#L32). This only works for subscriptable objects. Instead, implementing this control flow using `itertools.tee` allows us to bypass the requirement that the passed sequence be subscriptable. 