### PR TITLE
Added convenience function to remove systematic absences

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -678,7 +678,10 @@ class DataSet(pd.DataFrame):
         -------
         DataSet
         """
-        return self[~self.label_absences().ABSENT]
+        mask = is_absent(self.get_hkls(), self.spacegroup)
+        idx = self.index[mask]
+        self.drop(index=idx, inplace=True)
+        return self
 
     @inplace
     def infer_mtz_dtypes(self, inplace=False, index=True):

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -665,6 +665,22 @@ class DataSet(pd.DataFrame):
         return self
 
     @inplace
+    def remove_absences(self, inplace=False):
+        """
+        Remove systematically absent reflections in DataSet. 
+
+        Parameters
+        ----------
+        inplace : bool
+            Whether to add the column in place or to return a copy
+
+        Returns
+        -------
+        DataSet
+        """
+        return self[~self.label_absences().ABSENT]
+
+    @inplace
     def infer_mtz_dtypes(self, inplace=False, index=True):
         """
         Infers MTZ dtypes from column names and underlying data. This 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -225,7 +225,36 @@ def test_label_absences(data_fmodel, inplace, no_sg):
         assert "ABSENT" in result
         assert result["ABSENT"].dtype.name == "bool"
 
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("hkl_index", [True, False])
+def test_remove_absences(inplace, hkl_index):
+    """Test DataSet.remove_absences()"""
+    params = (34., 45., 98., 90., 90., 90.)
+    cell = gemmi.UnitCell(*params)
+    sg_1  = gemmi.SpaceGroup(1)
+    sg_19 = gemmi.SpaceGroup(19)
+    Hall = rs.utils.generate_reciprocal_asu(cell,  sg_1, 5., anomalous=False)
+    h,k,l = Hall.T
+    absent = rs.utils.is_absent(Hall, sg_19)
+    ds = rs.DataSet({
+        'H' : h,
+        'K' : k,
+        'L' : l,
+        'I' : np.ones(len(h)),
+    }, spacegroup=sg_19, cell=cell).infer_mtz_dtypes()
+    if hkl_index:
+        ds.set_index(['H', 'K', 'L'], inplace=True)
 
+    ds_test = ds.remove_absences(inplace=inplace)
+    ds_true = ds[~ds.label_absences().ABSENT]
+
+    assert len(ds_test) == len(Hall) - absent.sum()
+    assert np.array_equal(ds_test.get_hkls(), ds_true.get_hkls())
+
+    if inplace:
+        assert id(ds_test) == id(ds)
+
+        
 @pytest.mark.parametrize("cache", [True, False])
 def test_centrics(mtz_by_spacegroup, cache):
     """Test DataSet.centrics against DataSet.label_centrics"""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -253,6 +253,8 @@ def test_remove_absences(inplace, hkl_index):
 
     if inplace:
         assert id(ds_test) == id(ds)
+    else:
+        assert id(ds_test) != id(ds)
 
         
 @pytest.mark.parametrize("cache", [True, False])


### PR DESCRIPTION
I added a method to `rs.DataSet` which just drops systematically absent rows. This saves the user having to do something like
```python
ds = ds[~ds.label_absences().ABSENT]
```
which can now by done by
```python
ds = ds.remove_absences()
```
. This method supports the `inplace` argument, and by using `pd.DataFrame.drop` and operating at the `ds.index` level, I think it avoids using extra memory unnecessarily. This will be helpful for large, unmerged datasets. The recipe was a tad tricky to work out, so I figured we should just put it in a method. (Admittedly this part is a premature optimization, but I do think the method makes code cleaner at the user level). 

@JBGreisman , let me know what you think