### PR TITLE
use correct hkl resolution limits

### DIFF
--- a/reciprocalspaceship/utils/cell.py
+++ b/reciprocalspaceship/utils/cell.py
@@ -44,7 +44,7 @@ def generate_reciprocal_cell(cell, dmin, dtype=np.int32):
     -------
     hkl : np.array(int32)
     """
-    hmax,lmax,kmax = cell.get_hkl_limits(dmin)
+    hmax,kmax,lmax = cell.get_hkl_limits(dmin)
     hkl = np.meshgrid(
         np.linspace(-hmax-2, hmax+3, 2*hmax+6, dtype=dtype),
         np.linspace(-kmax-2, kmax+3, 2*kmax+6, dtype=dtype),


### PR DESCRIPTION
I had flipped the h,k,l axis limits when generating reciprocal cells which worked okay for low resolution tests with cube-ish cells. So, my test didn't catch it. I'll try to cook up a test later this week, but this is such an obvious bug that I will merge it first. I can probably relax the little oversampling I was doing in the original method as well. 