### PR TITLE
Fix reversion in dataset.py (#87)

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -12,7 +12,6 @@ from reciprocalspaceship.utils import (
     apply_to_hkl,
     bin_by_percentile,
     canonicalize_phases,
-    compute_dHKL,
     compute_structurefactor_multiplicity,
     from_structurefactor,
     hkl_to_asu,
@@ -786,7 +785,7 @@ class DataSet(pd.DataFrame):
         inplace : bool
             Whether to add the column in place or return a copy
         """
-        dHKL = compute_dHKL(self.get_hkls(), self.cell)
+        dHKL = self.cell.calculate_d_array(self.get_hkls())
         self["dHKL"] = DataSeries(dHKL, dtype="R", index=self.index)
         return self
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base", ":disableDependencyDashboard"],
-  "packageRules": [ 
+  "packageRules": [
     { "updateTypes": ["major", "minor", "patch", "digest", "bump"], "addLabels": ["version"] }
   ]
 }


### PR DESCRIPTION
When applying `black` to the codebase (#86), it appears that I reverted `DataSet.compute_dHKL()` to not use the changes made in #87. This PR corrects that reversion. 

After merging in this PR, `DataSet.compute_dHKL()` will use `gemmi` for computing resolution of reflections. 