### PR TITLE
Add decorators for gemmi argument checking

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1,6 +1,3 @@
-from functools import wraps
-from inspect import signature
-
 import gemmi
 import numpy as np
 import pandas as pd
@@ -8,6 +5,7 @@ from pandas.api.types import is_complex_dtype
 
 from reciprocalspaceship import dtypes
 from reciprocalspaceship.dataseries import DataSeries
+from reciprocalspaceship.decorators import inplace, range_indexed
 from reciprocalspaceship.utils import (
     apply_to_hkl,
     bin_by_percentile,
@@ -22,54 +20,6 @@ from reciprocalspaceship.utils import (
     phase_shift,
     to_structurefactor,
 )
-
-
-def inplace(f):
-    """
-    A decorator that applies the inplace argument.
-
-    Base function must have a bool param called "inplace" in  the call
-    signature. The position of `inplace` argument doesn't matter.
-    """
-
-    @wraps(f)
-    def wrapped(ds, *args, **kwargs):
-        sig = signature(f)
-        bargs = sig.bind(ds, *args, **kwargs)
-        bargs.apply_defaults()
-        if "inplace" in bargs.arguments:
-            if bargs.arguments["inplace"]:
-                return f(ds, *args, **kwargs)
-            else:
-                return f(ds.copy(), *args, **kwargs)
-        else:
-            raise KeyError(
-                f'"inplace" not found in local variables of @inplacemethod decorated function {f} '
-                "Edit your method definition to include `inplace=Bool`. "
-            )
-
-    return wrapped
-
-
-def range_indexed(f):
-    """
-    A decorator that presents the calling dataset with a range index.
-
-    This decorator facilitates writing methods that are agnostic to the
-    true indices in a DataSet. Original index columns are preserved through
-    wrapped function calls.
-    """
-
-    @wraps(f)
-    def wrapped(ds, *args, **kwargs):
-        names = ds.index.names
-        ds = ds._index_from_names([None], inplace=True)
-        result = f(ds, *args, **kwargs)
-        result = result._index_from_names(names, inplace=True)
-        ds = ds._index_from_names(names, inplace=True)
-        return result.__finalize__(ds)
-
-    return wrapped
 
 
 class DataSet(pd.DataFrame):

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -5,7 +5,12 @@ from pandas.api.types import is_complex_dtype
 
 from reciprocalspaceship import dtypes
 from reciprocalspaceship.dataseries import DataSeries
-from reciprocalspaceship.decorators import inplace, range_indexed
+from reciprocalspaceship.decorators import (
+    cellify,
+    inplace,
+    range_indexed,
+    spacegroupify,
+)
 from reciprocalspaceship.utils import (
     apply_to_hkl,
     bin_by_percentile,
@@ -98,14 +103,9 @@ class DataSet(pd.DataFrame):
         return self._spacegroup
 
     @spacegroup.setter
-    def spacegroup(self, val):
-        # GH#18: Type-checking for supported input types
-        if isinstance(val, gemmi.SpaceGroup) or (val is None):
-            self._spacegroup = val
-        elif isinstance(val, (str, int)):
-            self._spacegroup = gemmi.SpaceGroup(val)
-        else:
-            raise ValueError(f"Cannot construct gemmi.SpaceGroup from value: {val}")
+    @spacegroupify("sg")
+    def spacegroup(self, sg):
+        self._spacegroup = sg
 
     @property
     def cell(self):
@@ -113,14 +113,9 @@ class DataSet(pd.DataFrame):
         return self._cell
 
     @cell.setter
-    def cell(self, val):
-        # GH#18: Type-checking for supported input types
-        if isinstance(val, gemmi.UnitCell) or (val is None):
-            self._cell = val
-        elif isinstance(val, (list, tuple, np.ndarray)) and len(val) == 6:
-            self._cell = gemmi.UnitCell(*val)
-        else:
-            raise ValueError(f"Cannot construct gemmi.UnitCell from value: {val}")
+    @cellify("uc")
+    def cell(self, uc):
+        self._cell = uc
 
     @property
     def merged(self):

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -643,6 +643,8 @@ class DataSet(pd.DataFrame):
         inplace : bool
             Whether to add the column in place or to return a copy
         """
+        if self.spacegroup is None:
+            raise ValueError("DataSet space group must be set to label absences")
         self["CENTRIC"] = is_centric(self.get_hkls(), self.spacegroup)
         return self
 
@@ -657,6 +659,8 @@ class DataSet(pd.DataFrame):
         inplace : bool
             Whether to add the column in place or to return a copy
         """
+        if self.spacegroup is None:
+            raise ValueError("DataSet space group must be set to label absences")
         self["ABSENT"] = is_absent(self.get_hkls(), self.spacegroup)
         return self
 

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -1,0 +1,50 @@
+from functools import wraps
+from inspect import signature
+
+
+def inplace(f):
+    """
+    A decorator that applies the inplace argument.
+
+    Base function must have a bool param called "inplace" in  the call
+    signature. The position of `inplace` argument doesn't matter.
+    """
+
+    @wraps(f)
+    def wrapped(ds, *args, **kwargs):
+        sig = signature(f)
+        bargs = sig.bind(ds, *args, **kwargs)
+        bargs.apply_defaults()
+        if "inplace" in bargs.arguments:
+            if bargs.arguments["inplace"]:
+                return f(ds, *args, **kwargs)
+            else:
+                return f(ds.copy(), *args, **kwargs)
+        else:
+            raise KeyError(
+                f'"inplace" not found in local variables of @inplacemethod decorated function {f} '
+                "Edit your method definition to include `inplace=Bool`. "
+            )
+
+    return wrapped
+
+
+def range_indexed(f):
+    """
+    A decorator that presents the calling dataset with a range index.
+
+    This decorator facilitates writing methods that are agnostic to the
+    true indices in a DataSet. Original index columns are preserved through
+    wrapped function calls.
+    """
+
+    @wraps(f)
+    def wrapped(ds, *args, **kwargs):
+        names = ds.index.names
+        ds = ds._index_from_names([None], inplace=True)
+        result = f(ds, *args, **kwargs)
+        result = result._index_from_names(names, inplace=True)
+        ds = ds._index_from_names(names, inplace=True)
+        return result.__finalize__(ds)
+
+    return wrapped

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -1,6 +1,8 @@
 from functools import wraps
 from inspect import signature
 
+import gemmi
+
 
 def inplace(f):
     """

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -2,6 +2,7 @@ from functools import wraps
 from inspect import signature
 
 import gemmi
+import numpy as np
 
 
 def inplace(f):

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -52,6 +52,7 @@ def range_indexed(f):
 
 def _convert_spacegroup(val):
     """Helper method to try to convert value to gemmi.SpaceGroup"""
+    # GH#18: Type-checking for supported input types
     if isinstance(val, gemmi.SpaceGroup) or (val is None):
         return val
     elif isinstance(val, (str, int)):
@@ -74,8 +75,12 @@ def spacegroupify(func=None, *sg_args):
 
     When specified with argument names, such as ``@spacegroupify("parent_sg")``, only
     the provided argument names are coerced to gemmi.SpaceGroup. The provided argument
-    needs to exactly match an argument in the decorated function's call signature in order
+    needs to exactly match an argument in the decorated function's call signature
     for this decorator to coerce the input values.
+
+    Note
+    ----
+        ``None`` values are passed to the decorated function unchanged.
     """
     if not callable(func) and func is not None:
         sg_args = (func, *sg_args)
@@ -92,6 +97,61 @@ def spacegroupify(func=None, *sg_args):
             for arg in sg_args:
                 if arg in bargs.arguments:
                     bargs.arguments[arg] = _convert_spacegroup(bargs.arguments[arg])
+            return f(**bargs.arguments)
+
+        return wrapped
+
+    return _decorator(func) if callable(func) else _decorator
+
+
+def _convert_unitcell(val):
+    """Helper method to try to convert value to gemmi.UnitCell"""
+    # GH#18: Type-checking for supported input types
+    if isinstance(val, gemmi.UnitCell) or (val is None):
+        return val
+    elif isinstance(val, (list, tuple, np.ndarray)) and len(val) == 6:
+        return gemmi.UnitCell(*val)
+    else:
+        raise ValueError(f"Cannot construct gemmi.UnitCell from value: {val}")
+
+
+def cellify(func=None, *cell_args):
+    """
+    A decorator that converts unit cell arguments to gemmi.UnitCell objects.
+
+    This decorator facilitates writing methods that use gemmi.UnitCell objects
+    by allowing the method to accept unit cell arguments as tuples, lists, numpy
+    arrays, or gemmi.UnitCell without needing to write boilerplate argument
+    checking code.
+
+    When specified as ``@cellify`` or ``@cellify()``, any arguments named
+    "cell", "unit_cell", or "unitcell" are automatically coerced to provide
+    gemmi.UnitCell values.
+
+    When specified with argument names, such as ``@cellify("uc")``, only
+    the provided argument names are coerced to gemmi.UnitCell. The provided argument
+    needs to exactly match an argument in the decorated function's call signature
+    for this decorator to coerce the input values.
+
+    Note
+    ----
+        ``None`` values are passed to the decorated function unchanged.
+    """
+    if not callable(func) and func is not None:
+        cell_args = (func, *cell_args)
+
+    if len(cell_args) == 0:
+        cell_args = ("cell", "unit_cell", "unitcell")
+
+    def _decorator(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            sig = signature(f)
+            bargs = sig.bind(*args, **kwargs)
+            bargs.apply_defaults()
+            for arg in cell_args:
+                if arg in bargs.arguments:
+                    bargs.arguments[arg] = _convert_unitcell(bargs.arguments[arg])
             return f(**bargs.arguments)
 
         return wrapped

--- a/reciprocalspaceship/utils/asu.py
+++ b/reciprocalspaceship/utils/asu.py
@@ -1,6 +1,6 @@
 import numpy as np
-from gemmi import GroupOps, SpaceGroup
 
+from reciprocalspaceship.decorators import cellify, spacegroupify
 from reciprocalspaceship.utils.cell import generate_reciprocal_cell
 from reciprocalspaceship.utils.structurefactors import is_absent, is_centric
 from reciprocalspaceship.utils.symop import apply_to_hkl, phase_shift
@@ -34,6 +34,7 @@ asu_cases = {
 # fmt: on
 
 
+@spacegroupify("spacegroup")
 def in_asu(H, spacegroup):
     """
     Check to see if Miller indices are in the asymmetric unit of a space group.
@@ -42,7 +43,7 @@ def in_asu(H, spacegroup):
     ----------
     H : array
         n x 3 array of Miller indices
-    spacegroup : gemmi.SpaceGroup
+    spacegroup : str, int, or gemmi.SpaceGroup
         The space group to identify the asymmetric unit
 
     Returns
@@ -59,6 +60,7 @@ def in_asu(H, spacegroup):
     return asu_cases[idx](*H_ref.T)
 
 
+@spacegroupify("spacegroup")
 def hkl_to_asu(H, spacegroup, return_phase_shifts=False):
     """
     Map hkls to the asymmetric unit and optionally return shifts for the associated phases.
@@ -73,7 +75,7 @@ def hkl_to_asu(H, spacegroup, return_phase_shifts=False):
     ----------
     H : array
         n x 3 array of Miller indices
-    spacegroup : gemmi.SpaceGroup
+    spacegroup : str, int, or gemmi.SpaceGroup
         The space group to identify the asymmetric unit
     return_phase_shifts : bool (optional)
         If True, return the phase shift and phase multiplier to apply to each miller index
@@ -131,6 +133,7 @@ def hkl_to_asu(H, spacegroup, return_phase_shifts=False):
         return H_asu, isym
 
 
+@spacegroupify("sg")
 def hkl_to_observed(H, isym, sg, return_phase_shifts=False):
     """
     Apply symmetry operations to move miller indices in the reciprocal asymmetric unit to their originally observed locations. Optionally, return the corresponding phase shifts.
@@ -146,7 +149,7 @@ def hkl_to_observed(H, isym, sg, return_phase_shifts=False):
         n x 3 array of Miller indices
     isym : array
         integer array of isym values corresponding to the symmetry operator used to map the original miller index into the asu. see mtz spec for an explanation of this.
-    sg : gemmi.SpaceGroup
+    sg : str, int, or gemmi.SpaceGroup
         The space group to identify the asymmetric unit
     return_phase_shifts : bool (optional)
         If True, return the phase shift and phase multiplier to apply to each miller index
@@ -188,6 +191,8 @@ def hkl_to_observed(H, isym, sg, return_phase_shifts=False):
     return observed_H
 
 
+@cellify("cell")
+@spacegroupify("spacegroup")
 def generate_reciprocal_asu(cell, spacegroup, dmin, anomalous=False):
     """
     Generate the Miller indices of the reflections in the reciprocal ASU.
@@ -199,10 +204,10 @@ def generate_reciprocal_asu(cell, spacegroup, dmin, anomalous=False):
 
     Parameters
     ----------
-    cell : gemmi.UnitCell
-        A gemmi cell object.
-    spacegroup : gemmi.SpaceGroup
-        A gemmi spacegroup object.
+    cell : tuple, list, np.ndarray of paramaters, or gemmi.UnitCell
+        Unit cell parameters or UnitCell object
+    spacegroup : str, int, gemmi.SpaceGroup
+        Space group to identify asymmetric unit
     dmin : float
         Maximum resolution of the data in Å
     anomalous : bool

--- a/reciprocalspaceship/utils/cell.py
+++ b/reciprocalspaceship/utils/cell.py
@@ -1,8 +1,9 @@
 import numpy as np
 
-import reciprocalspaceship as rs
+from reciprocalspaceship.decorators import cellify
 
 
+@cellify
 def compute_dHKL(H, cell):
     """
     Compute the real space lattice plane spacing, d, associated with
@@ -12,8 +13,8 @@ def compute_dHKL(H, cell):
     ----------
     H : array
         An nx3 array of numerical miller indices.
-    cell : gemmi.UnitCell
-        The gemmi UnitCell object with the cell parameters.
+    cell : tuple, list, np.ndarray of cell parameters, or gemmi.UnitCell
+        Unit cell parameters
 
     Returns
     -------
@@ -28,14 +29,15 @@ def compute_dHKL(H, cell):
     return dhkls[inverse]
 
 
+@cellify
 def generate_reciprocal_cell(cell, dmin, dtype=np.int32):
     """
     Generate the miller indices of the full P1 reciprocal cell.
 
     Parameters
     ----------
-    cell : gemmi.UnitCell
-        A gemmi cell object.
+    cell : tuple, list, np.ndarray of cell parameters, or gemmi.UnitCell
+        Unit cell parameters
     dmin : float
         Maximum resolution of the data in Å
     dtype : np.dtype (optional)

--- a/reciprocalspaceship/utils/phases.py
+++ b/reciprocalspaceship/utils/phases.py
@@ -1,6 +1,8 @@
 import gemmi
 import numpy as np
 
+from reciprocalspaceship.decorators import spacegroupify
+
 
 def canonicalize_phases(phases, deg=True):
     """
@@ -15,6 +17,7 @@ def canonicalize_phases(phases, deg=True):
         raise TypeError(f"deg has type {type(deg)}, but it should have type bool")
 
 
+@spacegroupify
 def get_phase_restrictions(H, spacegroup):
     """
     Return phase restrictions for Miller indices in a given space group.
@@ -27,7 +30,7 @@ def get_phase_restrictions(H, spacegroup):
     ----------
     H : array
         n x 3 array of Miller indices
-    spacegroup : gemmi.SpaceGroup
+    spacegroup : str, int, gemmi.SpaceGroup
         Space group for determining phase restrictions
 
     Returns

--- a/reciprocalspaceship/utils/stats.py
+++ b/reciprocalspaceship/utils/stats.py
@@ -1,9 +1,11 @@
 import numpy as np
-import pandas as pd
 
 import reciprocalspaceship as rs
+from reciprocalspaceship.decorators import cellify, spacegroupify
 
 
+@cellify
+@spacegroupify
 def compute_redundancy(
     hobs, cell, spacegroup, full_asu=True, anomalous=False, dmin=None
 ):
@@ -15,10 +17,10 @@ def compute_redundancy(
     hobs : np.array(int)
         An n by 3 array of observed miller indices which are not necessarily
         in the reciprocal asymmetric unit
-    spacegroup : gemmi.SpaceGroup
-        A gemmi SpaceGroup object.
-    cell : gemmi.UnitCell
-        A gemmi UnitCell object.
+    cell : tuple, list, np.ndarray of cell parameters, or gemmi.UnitCell
+        Unit cell parameters
+    spacegroup : str, int, or gemmi.SpaceGroup
+        The space group of the dataset
     full_asu : bool (optional)
         Include all the reflections in the calculation irrespective of whether they were
         observed.

--- a/reciprocalspaceship/utils/structurefactors.py
+++ b/reciprocalspaceship/utils/structurefactors.py
@@ -2,6 +2,7 @@ import numpy as np
 from gemmi import GroupOps, SpaceGroup
 
 import reciprocalspaceship as rs
+from reciprocalspaceship.decorators import spacegroupify
 
 
 def to_structurefactor(sfamps, phases):
@@ -54,6 +55,7 @@ def from_structurefactor(sfs):
     return sf, phase
 
 
+@spacegroupify
 def compute_structurefactor_multiplicity(H, sg, include_centering=True):
     """
     Compute the multiplicity of each reflection in ``H``.
@@ -62,7 +64,7 @@ def compute_structurefactor_multiplicity(H, sg, include_centering=True):
     ----------
     H : array
         n x 3 array of Miller indices
-    spacegroup : gemmi.SpaceGroup, gemmi.GroupOps
+    spacegroup : str, int, gemmi.SpaceGroup
         The space group to identify the asymmetric unit
     include_centering : bool
         Whether or not to include the multiplicity inherent in the lattice centering.
@@ -75,16 +77,7 @@ def compute_structurefactor_multiplicity(H, sg, include_centering=True):
         an array of length n containing the multiplicity
         of each hkl.
     """
-    if isinstance(sg, SpaceGroup):
-        group_ops = sg.operations()
-    elif isinstance(sg, GroupOps):
-        group_ops = sg
-    else:
-        raise ValueError(
-            f"gemmi.SpaceGroup or gemmi.GroupOps expected for parameter sg. "
-            f"Received object of type: ({type(sg)}) instead."
-        )
-
+    group_ops = sg.operations()
     is_centric = group_ops.is_centric()
 
     # Lookup based on centering is equivalent to counting the number of translational
@@ -105,6 +98,7 @@ def compute_structurefactor_multiplicity(H, sg, include_centering=True):
     return eps / L
 
 
+@spacegroupify
 def is_centric(H, spacegroup):
     """
     Determine if Miller indices are centric in a given spacegroup
@@ -113,7 +107,7 @@ def is_centric(H, spacegroup):
     ----------
     H : array
         n x 3 array of Miller indices
-    spacegroup : gemmi.SpaceGroup, gemmi.GroupOps
+    spacegroup : str, int, gemmi.SpaceGroup
         The space group in which to classify centrics
 
     Returns
@@ -121,21 +115,13 @@ def is_centric(H, spacegroup):
     centric : array
         Boolean arreay with len(centric) == np.shape(H)[0] == n
     """
-    if isinstance(spacegroup, SpaceGroup):
-        group_ops = spacegroup.operations()
-    elif isinstance(spacegroup, GroupOps):
-        group_ops = spacegroup
-    else:
-        raise ValueError(
-            f"gemmi.SpaceGroup or gemmi.GroupOps expected for parameter sg. "
-            f"Received object of type: ({type(spacegroup)}) instead."
-        )
-
+    group_ops = spacegroup.operations()
     hkl, inverse = np.unique(H, axis=0, return_inverse=True)
     centric = group_ops.centric_flag_array(hkl)
     return centric[inverse]
 
 
+@spacegroupify
 def is_absent(H, spacegroup):
     """
     Determine if Miller indices are systematically absent in a given
@@ -145,7 +131,7 @@ def is_absent(H, spacegroup):
     ----------
     H : array
         n x 3 array of Miller indices
-    spacegroup : gemmi.SpaceGroup, gemmi.GroupOps
+    spacegroup : str, int, gemmi.SpaceGroup
         The space group in which to classify systematic absences
 
     Returns
@@ -153,14 +139,4 @@ def is_absent(H, spacegroup):
     absent : array
         Boolean array of length n. absent[i] == True if H[i] is systematically absent in sg.
     """
-    if isinstance(spacegroup, SpaceGroup):
-        group_ops = spacegroup.operations()
-    elif isinstance(spacegroup, GroupOps):
-        group_ops = spacegroup
-    else:
-        raise ValueError(
-            f"gemmi.SpaceGroup or gemmi.GroupOps expected for parameter sg. "
-            f"Received object of type: ({type(spacegroup)}) instead."
-        )
-
-    return group_ops.systematic_absences(H)
+    return spacegroup.operations().systematic_absences(H)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,73 @@
+import gemmi
+import pytest
+
+from reciprocalspaceship.decorators import cellify, spacegroupify
+
+
+@spacegroupify
+def _function_bare(spacegroup=None, arg2=None):
+    """spacegroup argument should be coerced to gemmi.SpaceGroup"""
+    return spacegroup, arg2
+
+
+@spacegroupify()
+def _function_empty(spacegroup=None, arg2=None):
+    """spacegroup argument should be coerced to gemmi.SpaceGroup"""
+    return spacegroup, arg2
+
+
+@spacegroupify("arg2")
+def _function_arg(spacegroup=None, arg2=None):
+    """arg2 argument should be coerced to gemmi.SpaceGroup"""
+    return spacegroup, arg2
+
+
+@pytest.mark.parametrize("sg", [None, 1, gemmi.SpaceGroup(1), "P 1", 1.0])
+@pytest.mark.parametrize("extra_arg", [1, 2, 3])
+@pytest.mark.parametrize("function", [_function_bare, _function_empty])
+def test_spacegroupify_default(sg, function, extra_arg):
+    """Test spacegroupify decorator with default arguments"""
+
+    if isinstance(sg, float):
+        with pytest.raises(ValueError):
+            result_spacegroup, result_arg2 = function(sg, arg2=extra_arg)
+    else:
+        result_spacegroup, result_arg2 = function(sg, arg2=extra_arg)
+
+        # arg2 argument should be unchanged
+        assert result_arg2 == extra_arg
+
+        # check spacegroup coercion to gemmi instance
+        if sg is None:
+            assert result_spacegroup is None
+        elif isinstance(sg, gemmi.SpaceGroup):
+            assert result_spacegroup.xhm() == sg.xhm()
+        else:
+            assert isinstance(result_spacegroup, gemmi.SpaceGroup)
+            expected = gemmi.SpaceGroup(sg)
+            assert result_spacegroup.xhm() == expected.xhm()
+
+
+@pytest.mark.parametrize("sg", [1, 2, 3])
+@pytest.mark.parametrize("arg2", [None, 1, gemmi.SpaceGroup(1), "P 1", 1.0])
+def test_spacegroupify_arg(sg, arg2):
+    """Test spacegroupify decorator with provided arguments"""
+
+    if isinstance(arg2, float):
+        with pytest.raises(ValueError):
+            result_spacegroup, result_arg2 = _function_arg(sg, arg2=arg2)
+    else:
+        result_spacegroup, result_arg2 = _function_arg(sg, arg2=arg2)
+
+        # spacegroup argument should be unchanged
+        assert result_spacegroup == sg
+
+        # check arg2 coercion to gemmi instance
+        if arg2 is None:
+            assert result_arg2 is None
+        elif isinstance(arg2, gemmi.SpaceGroup):
+            assert result_arg2.xhm() == arg2.xhm()
+        else:
+            assert isinstance(result_arg2, gemmi.SpaceGroup)
+            expected = gemmi.SpaceGroup(arg2)
+            assert result_arg2.xhm() == expected.xhm()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,4 +1,5 @@
 import gemmi
+import numpy as np
 import pytest
 
 from reciprocalspaceship.decorators import cellify, spacegroupify
@@ -22,20 +23,20 @@ def _function_arg(spacegroup=None, arg2=None):
     return spacegroup, arg2
 
 
-@pytest.mark.parametrize("sg", [None, 1, gemmi.SpaceGroup(1), "P 1", 1.0])
-@pytest.mark.parametrize("extra_arg", [1, 2, 3])
 @pytest.mark.parametrize("function", [_function_bare, _function_empty])
-def test_spacegroupify_default(sg, function, extra_arg):
+@pytest.mark.parametrize("sg", [None, 1, gemmi.SpaceGroup(1), "P 1", 1.0])
+@pytest.mark.parametrize("arg2", [1, 2, 3])
+def test_spacegroupify_default(function, sg, arg2):
     """Test spacegroupify decorator with default arguments"""
 
     if isinstance(sg, float):
         with pytest.raises(ValueError):
-            result_spacegroup, result_arg2 = function(sg, arg2=extra_arg)
+            result_spacegroup, result_arg2 = function(sg, arg2=arg2)
     else:
-        result_spacegroup, result_arg2 = function(sg, arg2=extra_arg)
+        result_spacegroup, result_arg2 = function(sg, arg2=arg2)
 
         # arg2 argument should be unchanged
-        assert result_arg2 == extra_arg
+        assert result_arg2 == arg2
 
         # check spacegroup coercion to gemmi instance
         if sg is None:
@@ -71,3 +72,92 @@ def test_spacegroupify_arg(sg, arg2):
             assert isinstance(result_arg2, gemmi.SpaceGroup)
             expected = gemmi.SpaceGroup(arg2)
             assert result_arg2.xhm() == expected.xhm()
+
+
+@cellify
+def _function2_bare(cell=None, arg2=None):
+    """cell argument should be coerced to gemmi.UnitCell"""
+    return cell, arg2
+
+
+@cellify()
+def _function2_empty(cell=None, arg2=None):
+    """cell argument should be coerced to gemmi.UnitCell"""
+    return cell, arg2
+
+
+@cellify("arg2")
+def _function2_arg(cell=None, arg2=None):
+    """arg2 argument should be coerced to gemmi.UnitCell"""
+    return cell, arg2
+
+
+@pytest.mark.parametrize("function", [_function2_bare, _function2_empty])
+@pytest.mark.parametrize(
+    "cell",
+    [
+        None,
+        (1.0, 1.0, 1.0, 90.0, 90.0, 90.0),
+        [1.0, 1.0, 1.0, 90.0, 90.0, 90.0],
+        np.array([1.0, 1.0, 1.0, 90.0, 90.0, 90.0]),
+        gemmi.UnitCell(1.0, 1.0, 1.0, 90.0, 90.0, 90.0),
+        1.0,
+    ],
+)
+@pytest.mark.parametrize("arg2", [1, 2, 3])
+def test_cellify_default(function, cell, arg2):
+    """Test cellify decorator with default arguments"""
+
+    if isinstance(cell, float):
+        with pytest.raises(ValueError):
+            result_cell, result_arg2 = function(cell, arg2=arg2)
+    else:
+        result_cell, result_arg2 = function(cell, arg2=arg2)
+
+        # arg2 argument should be unchanged
+        assert result_arg2 == arg2
+
+        # check unit cell coercion to gemmi instance
+        if cell is None:
+            assert result_cell is None
+        elif isinstance(cell, gemmi.UnitCell):
+            assert np.array_equal(result_cell.parameters, cell.parameters)
+        else:
+            assert isinstance(result_cell, gemmi.UnitCell)
+            expected = gemmi.UnitCell(*cell)
+            assert np.array_equal(result_cell.parameters, expected.parameters)
+
+
+@pytest.mark.parametrize("cell", [1, 2, 3])
+@pytest.mark.parametrize(
+    "arg2",
+    [
+        None,
+        (1.0, 1.0, 1.0, 90.0, 90.0, 90.0),
+        [1.0, 1.0, 1.0, 90.0, 90.0, 90.0],
+        np.array([1.0, 1.0, 1.0, 90.0, 90.0, 90.0]),
+        gemmi.UnitCell(1.0, 1.0, 1.0, 90.0, 90.0, 90.0),
+        1.0,
+    ],
+)
+def test_cellify_arg(cell, arg2):
+    """Test cellify decorator with provided arguments"""
+
+    if isinstance(arg2, float):
+        with pytest.raises(ValueError):
+            result_cell, result_arg2 = _function2_arg(cell, arg2=arg2)
+    else:
+        result_cell, result_arg2 = _function2_arg(cell, arg2=arg2)
+
+        # cell argument should be unchanged
+        assert result_cell == cell
+
+        # check arg2 coercion to gemmi instance
+        if arg2 is None:
+            assert result_arg2 is None
+        elif isinstance(arg2, gemmi.UnitCell):
+            assert np.array_equal(result_arg2.parameters, arg2.parameters)
+        else:
+            assert isinstance(result_arg2, gemmi.UnitCell)
+            expected = gemmi.UnitCell(*arg2)
+            assert np.array_equal(result_arg2.parameters, expected.parameters)

--- a/tests/utils/test_centrics.py
+++ b/tests/utils/test_centrics.py
@@ -6,11 +6,7 @@ import pytest
 import reciprocalspaceship as rs
 
 
-@pytest.mark.parametrize(
-    "sg_type",
-    [gemmi.SpaceGroup, gemmi.GroupOps],
-)
-def test_is_centric(sgtbx_by_xhm, sg_type):
+def test_is_centric(sgtbx_by_xhm):
     """
     Test rs.utils.is_centric using reference data generated from sgtbx.
     """
@@ -22,9 +18,5 @@ def test_is_centric(sgtbx_by_xhm, sg_type):
 
     H = reference[["h", "k", "l"]].to_numpy()
     ref_centric = reference["is_centric"].to_numpy()
-    if sg_type is gemmi.SpaceGroup:
-        sg = gemmi.SpaceGroup(xhm)
-    elif sg_type is gemmi.GroupOps:
-        sg = gemmi.SpaceGroup(xhm).operations()
-    centric = rs.utils.is_centric(H, sg)
+    centric = rs.utils.is_centric(H, xhm)
     assert np.array_equal(centric, ref_centric)

--- a/tests/utils/test_multiplicity.py
+++ b/tests/utils/test_multiplicity.py
@@ -6,11 +6,7 @@ import pytest
 import reciprocalspaceship as rs
 
 
-@pytest.mark.parametrize(
-    "sg_type",
-    [gemmi.SpaceGroup, gemmi.GroupOps],
-)
-def test_multiplicity_epsilon(sgtbx_by_xhm, sg_type):
+def test_multiplicity_epsilon(sgtbx_by_xhm):
     """
     Test rs.utils.compute_structurefactor_multiplicity using reference
     data generated from sgtbx and gemmi.
@@ -32,13 +28,9 @@ def test_multiplicity_epsilon(sgtbx_by_xhm, sg_type):
     gemmi_epsilon_without_centering = reference[
         "gemmi_epsilon_without_centering"
     ].to_numpy()  # This is computed by gemmi
-    if sg_type is gemmi.SpaceGroup:
-        sg = gemmi.SpaceGroup(xhm)
-    elif sg_type is gemmi.GroupOps:
-        sg = gemmi.SpaceGroup(xhm).operations()
-    epsilon = rs.utils.compute_structurefactor_multiplicity(H, sg)
+    epsilon = rs.utils.compute_structurefactor_multiplicity(H, xhm)
     epsilon_without_centering = rs.utils.compute_structurefactor_multiplicity(
-        H, sg, include_centering=False
+        H, xhm, include_centering=False
     )
     assert np.array_equal(epsilon_without_centering, sgtbx_epsilon_without_centering)
     assert np.array_equal(epsilon_without_centering, gemmi_epsilon_without_centering)

--- a/tests/utils/test_structurefactors.py
+++ b/tests/utils/test_structurefactors.py
@@ -54,25 +54,3 @@ def test_from_structurefactor():
     assert isinstance(phase.dtype, rs.PhaseDtype)
     assert np.isclose(sf.to_numpy(), np.abs(sfs)).all()
     assert np.isclose(phase.to_numpy(), np.angle(sfs, deg=True)).all()
-
-
-@pytest.mark.parametrize(
-    "sg",
-    [
-        gemmi.SpaceGroup(1),
-        gemmi.SpaceGroup(1).operations(),
-        "invalid",
-        None,
-    ],
-)
-def test_structurefactor_multiplicity_valueerror(sg):
-    """
-    Test rs.utils.compute_structurefactor_multiplicity() raises
-    ValueError when invoked with invalid spacegroup
-    """
-    H = np.array([[1, 1, 1]])
-    if isinstance(sg, gemmi.SpaceGroup) or isinstance(sg, gemmi.GroupOps):
-        epsilon = rs.utils.compute_structurefactor_multiplicity(H, sg)
-    else:
-        with pytest.raises(ValueError):
-            epsilon = rs.utils.compute_structurefactor_multiplicity(H, sg)


### PR DESCRIPTION
Fixes #92.

It is common in `rs` to write functions that take `gemmi.SpaceGroup` or `gemmi.UnitCell` instances as arguments. In order to make these methods more flexible, it is often useful to add error checking code so that if an `int` is provided instead of a `gemmi.SpaceGroup`, the method generates the equivalent `gemmi` object instance. This was done for the `DataSet.cell` and `DataSet.spacegroup` setter methods to address #18.

This PR generalizes this idea using `@spacegroupify` and `@cellify` decorators to avoid needing to write boiler plate argument checking code. This allows one to write a function as if it is guaranteed that the input argument is a `gemmi` object, while still being able to input that argument flexibly. For example:

```python
from reciprocalspaceship.decorators import spacegroupify

@spacegroupify
def get_xhm(spacegroup=None):
    return spacegroup.xhm()

import gemmi
print(get_xhm(gemmi.SpaceGroup("1"))) # prints 'P 1'
print(get_xhm(1))                     # prints 'P 1'
print(get_xhm("P1"))                  # prints 'P 1'
```