### PR TITLE
Ensure consistent column ordering in `DataSet.unstack_anomalous()`

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -951,11 +951,11 @@ class DataSet(pd.DataFrame):
             dataset_minus, how="outer", on=["H", "K", "L"], suffixes=suffixes
         )
 
-        # Handle centric reflections
+        # Update centric reflections to use "aimless"-style formatting
         columns = list(columns)[3:]  # First 3 items are always ["H", "K", "L"]
         plus_columns = [c + suffixes[0] for c in columns]
         minus_columns = [c + suffixes[1] for c in columns]
-        centrics = result.label_centrics()["CENTRIC"]
+        centrics = result.centrics.index
         result.loc[centrics, minus_columns] = result.loc[centrics, plus_columns].values
 
         if "M/ISYM" not in self.columns and self.merged:

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -937,21 +937,22 @@ class DataSet(pd.DataFrame):
             raise ValueError(f"Expected suffixes to be tuple or list of len() of 2")
 
         # Separate DataSet into Friedel(+) and Friedel(-)
-        columns = set(columns).union(set(["H", "K", "L"]))
+        # GH#97: switch to Python dict instead of set to preserve column order
+        columns = dict.fromkeys(["H", "K", "L"] + list(columns))
         dataset = self.hkl_to_asu()
-        if "PARTIAL" in columns:
-            columns.remove("PARTIAL")
-        for column in columns:
+        if "PARTIAL" in columns.keys():
+            columns.pop("PARTIAL")
+        for column in columns.keys():
             dataset[column] = dataset[column].to_friedel_dtype()
         dataset_plus = dataset.loc[dataset["M/ISYM"] % 2 == 1].copy()
         dataset_minus = dataset.loc[dataset["M/ISYM"] % 2 == 0].copy()
-        dataset_minus = dataset_minus.loc[:, columns]
+        dataset_minus = dataset_minus.loc[:, columns.keys()]
         result = dataset_plus.merge(
             dataset_minus, how="outer", on=["H", "K", "L"], suffixes=suffixes
         )
 
         # Handle centric reflections
-        columns = columns.difference(set(["H", "K", "L"]))
+        columns = list(columns)[3:]  # First 3 items are always ["H", "K", "L"]
         plus_columns = [c + suffixes[0] for c in columns]
         minus_columns = [c + suffixes[1] for c in columns]
         centrics = result.label_centrics()["CENTRIC"]

--- a/tests/test_dataset_anomalous.py
+++ b/tests/test_dataset_anomalous.py
@@ -106,7 +106,7 @@ def test_unstack_anomalous_unmerged(data_unmerged):
 
 
 @pytest.mark.parametrize("rangeindexed", [True, False])
-def test_roundtrip_merged(data_merged, rangeindexed):
+def test_roundtrip_stack_unstack_merged(data_merged, rangeindexed):
     """
     Test that DataSet is unchanged by roundtrip call of DataSet.stack_anomalous()
     followed by DataSet.unstack_anomalous()
@@ -122,5 +122,27 @@ def test_roundtrip_merged(data_merged, rangeindexed):
     # Re-order columns if needed
     result = result[data.columns]
 
-    # DataSet.merge() operations seem to recast index dtypes
-    assert_frame_equal(result, data, check_index_type=False)
+    assert_frame_equal(result, data)
+
+
+@pytest.mark.parametrize("rangeindexed", [True, False])
+def test_roundtrip_unstack_stack_merged(data_merged, rangeindexed):
+    """
+    Test that DataSet is unchanged by roundtrip call of DataSet.unstack_anomalous()
+    followed by DataSet.stack_anomalous()
+    """
+
+    stacked = data_merged.stack_anomalous()
+
+    if rangeindexed:
+        data = stacked.reset_index()
+    else:
+        data = stacked
+
+    unstacked = data.unstack_anomalous(["I", "SIGI", "N"])
+    result = unstacked.stack_anomalous()
+
+    # Re-order columns if needed
+    result = result[data.columns]
+
+    assert_frame_equal(result, data)

--- a/tests/test_dataset_anomalous.py
+++ b/tests/test_dataset_anomalous.py
@@ -123,6 +123,7 @@ def test_roundtrip_stack_unstack_merged(data_merged, rangeindexed):
     result = result[data.columns]
 
     assert_frame_equal(result, data)
+    assert result._index_dtypes == data._index_dtypes
 
 
 @pytest.mark.parametrize("rangeindexed", [True, False])
@@ -132,17 +133,18 @@ def test_roundtrip_unstack_stack_merged(data_merged, rangeindexed):
     followed by DataSet.stack_anomalous()
     """
 
-    stacked = data_merged.stack_anomalous()
-
     if rangeindexed:
-        data = stacked.reset_index()
+        data = data_merged.reset_index()
     else:
-        data = stacked
+        data = data_merged
 
-    unstacked = data.unstack_anomalous(["I", "SIGI", "N"])
+    stacked = data.stack_anomalous()
+
+    unstacked = stacked.unstack_anomalous(["I", "SIGI", "N"])
     result = unstacked.stack_anomalous()
 
     # Re-order columns if needed
-    result = result[data.columns]
+    result = result[stacked.columns]
 
-    assert_frame_equal(result, data)
+    assert_frame_equal(result, stacked, check_index_type=False)
+    assert result._index_dtypes == stacked._index_dtypes


### PR DESCRIPTION
`DataSet.unstack_anomalous()` would sometimes produce new two-column anomalous `DataSets` in which the newly created anomalous columns were in different orders. This would occur because internally the function used a `set` to keep track of the new columns. Since the plus-Friedel columns were suffixed with `(+)` and the minus-Friedel with `(-)`, this could produce different orders to the columns in the `set`. 

This bug made it so that round-trip operations of `DataSet.unstack_anomalous()` followed by `DataSet.stack_anomalous()` sometimes produced a `ValueError` (#97 ), depending on the Python version being used. 

This PR updates `DataSet.unstack_anomalous()` to internally use a `dict` for keeping track of the relevant columns. As of Python 3.7+ this preserves the order of input keys. 