### PR TITLE
`DataSet.write_mtz()` should not move unmerged reflections to reciprocal ASU

### DIFF
--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from reciprocalspaceship import DataSet
 from reciprocalspaceship.dtypes.base import MTZDtype
+from reciprocalspaceship.utils import in_asu
 
 
 def from_gemmi(gemmi_mtz):
@@ -97,7 +98,12 @@ def to_gemmi(dataset, skip_problem_mtztypes=False):
 
     # Handle Unmerged data
     if not dataset.merged:
-        dataset.hkl_to_asu(inplace=True)
+        all_in_asu = in_asu(dataset.get_hkls(), dataset.spacegroup).all()
+        if all_in_asu and "M/ISYM" in dataset.columns:
+            unmerged_in_asu = True
+        else:
+            unmerged_in_asu = False
+            dataset.hkl_to_asu(inplace=True)
 
     # Construct data for Mtz object.
     mtz.add_dataset("reciprocalspaceship")
@@ -123,7 +129,7 @@ def to_gemmi(dataset, skip_problem_mtztypes=False):
     mtz.set_data(temp[columns].to_numpy(dtype="float32"))
 
     # Handle Unmerged data
-    if not dataset.merged:
+    if not dataset.merged and not unmerged_in_asu:
         dataset.hkl_to_observed(m_isym="M/ISYM", inplace=True)
 
     return mtz

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -97,7 +97,7 @@ def to_gemmi(dataset, skip_problem_mtztypes=False):
 
     # Handle Unmerged data
     if not dataset.merged:
-        dataset.hkl_to_asu(inplace=True)
+        dataset = dataset.hkl_to_asu(inplace=False)
 
     # Construct data for Mtz object.
     mtz.add_dataset("reciprocalspaceship")

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -99,10 +99,7 @@ def to_gemmi(dataset, skip_problem_mtztypes=False):
     # Handle Unmerged data
     if not dataset.merged:
         all_in_asu = in_asu(dataset.get_hkls(), dataset.spacegroup).all()
-        if all_in_asu and "M/ISYM" in dataset.columns:
-            unmerged_in_asu = True
-        else:
-            unmerged_in_asu = False
+        if not all_in_asu:
             dataset.hkl_to_asu(inplace=True)
 
     # Construct data for Mtz object.
@@ -129,7 +126,7 @@ def to_gemmi(dataset, skip_problem_mtztypes=False):
     mtz.set_data(temp[columns].to_numpy(dtype="float32"))
 
     # Handle Unmerged data
-    if not dataset.merged and not unmerged_in_asu:
+    if not dataset.merged and not all_in_asu:
         dataset.hkl_to_observed(m_isym="M/ISYM", inplace=True)
 
     return mtz

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -97,7 +97,7 @@ def to_gemmi(dataset, skip_problem_mtztypes=False):
 
     # Handle Unmerged data
     if not dataset.merged:
-        dataset = dataset.hkl_to_asu(inplace=False)
+        dataset.hkl_to_asu(inplace=True)
 
     # Construct data for Mtz object.
     mtz.add_dataset("reciprocalspaceship")
@@ -121,6 +121,10 @@ def to_gemmi(dataset, skip_problem_mtztypes=False):
                 f"To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True"
             )
     mtz.set_data(temp[columns].to_numpy(dtype="float32"))
+
+    # Handle Unmerged data
+    if not dataset.merged:
+        dataset.hkl_to_observed(m_isym="M/ISYM", inplace=True)
 
     return mtz
 

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -123,8 +123,8 @@ def test_roundtrip_unmerged(data_unmerged, label_centrics):
     temp2 = tempfile.NamedTemporaryFile(suffix=".mtz")
     data_unmerged.write_mtz(temp.name)
     data2 = rs.read_mtz(temp.name)
+    data2 = data2[data_unmerged.columns]  # Ensure consistent column ordering
     data2.write_mtz(temp2.name)
-
     assert filecmp.cmp(temp.name, temp2.name)
     assert_frame_equal(data_unmerged, data2)
     assert data_unmerged.merged == data2.merged

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -134,11 +134,14 @@ def test_roundtrip_unmerged(data_unmerged, label_centrics):
     temp2.close()
 
 
-def test_unmerged_after_write(data_unmerged):
+@pytest.mark.parametrize("in_asu", [True, False])
+def test_unmerged_after_write(data_unmerged, in_asu):
     """
     #110: Test that unmerged DataSet objects are unchanged following calls to
     DataSet.write_mtz()
     """
+    if in_asu:
+        data_unmerged.hkl_to_asu(inplace=True)
     expected = data_unmerged.copy()
     data_unmerged.write_mtz("/dev/null")
     assert_frame_equal(data_unmerged, expected)

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -51,7 +51,7 @@ def test_write_merged_nocell(IOtest_mtz):
 
 
 @pytest.mark.parametrize("skip_problem_mtztypes", [True, False])
-def test_write_merged_nocell(IOtest_mtz, skip_problem_mtztypes):
+def test_write_merged_nonMTZDtype(IOtest_mtz, skip_problem_mtztypes):
     """
     Test skip_problem_mtztypes flag of DataSet.write_mtz()
     """


### PR DESCRIPTION
This PR fixes #110 to ensure that unmerged reflections are not moved to the reciprocal ASU after a call to `DataSet.write_mtz()`. 