### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     # Skip CI if 'skip ci' is contained in latest commit message
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     author_email="kmdalton@g.harvard.edu, greisman@g.harvard.edu",
     url="https://hekstra-lab.github.io/reciprocalspaceship/",
     project_urls=PROJECT_URLS,
-    python_requires=">3.6",
+    python_requires=">3.7",
     install_requires=[
         "gemmi>=0.4.2, <=0.5.0",
         "pandas>=1.2.0, <=1.3.4",


### PR DESCRIPTION
Numpy recently removed support for Python 3.7. This PR follows suit, changing the Python requirements to >3.8 and adjusting the CI accordingly.