### PR TITLE
Raise ValueError when stack_anomalous() will result in duplicate column names

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -897,10 +897,10 @@ class DataSet(pd.DataFrame):
         for lab in new_labels:
             if lab in self.columns:
                 raise ValueError(
-                    f"Stacking anomalous data will result in duplicate column " 
+                    f"Stacking anomalous data will result in duplicate column "
                     f"names. Rename or drop column '{lab}' and try again."
                 )
-        
+
         # Map Friedel reflections to +/- ASU
         centrics = self.label_centrics()["CENTRIC"]
         dataset_plus = self.drop(columns=list(minus_labels))

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -810,6 +810,8 @@ class DataSet(pd.DataFrame):
         - A ValueError is raised if invoked with an unmerged DataSet
         - It is assumed that Friedel-plus column labels are suffixed with (+),
           and that Friedel-minus column labels are suffixed with (-)
+        - A ValueError is raised if stripping suffixes will lead to a duplicate
+          column name
         - Corresponding column labels are expected to be given in the same order
 
         Parameters
@@ -890,6 +892,15 @@ class DataSet(pd.DataFrame):
                     f"{self[plus].dtype} and {self[minus].dtype}"
                 )
 
+        # confirm that new_labels doesn't create duplicate column names
+        new_labels = [l.rstrip(suffixes[0]) for l in plus_labels]
+        for lab in new_labels:
+            if lab in self.columns:
+                raise ValueError(
+                    f"Stacking anomalous data will result in duplicate column " 
+                    f"names. Rename or drop column '{lab}' and try again."
+                )
+        
         # Map Friedel reflections to +/- ASU
         centrics = self.label_centrics()["CENTRIC"]
         dataset_plus = self.drop(columns=list(minus_labels))
@@ -897,7 +908,6 @@ class DataSet(pd.DataFrame):
         dataset_minus.apply_symop(gemmi.Op("-x,-y,-z"), inplace=True)
 
         # Rename columns and update dtypes
-        new_labels = [l.rstrip(suffixes[0]) for l in plus_labels]
         column_mapping_plus = dict(zip(plus_labels, new_labels))
         column_mapping_minus = dict(zip(minus_labels, new_labels))
         dataset_plus.rename(columns=column_mapping_plus, inplace=True)

--- a/tests/test_dataset_anomalous.py
+++ b/tests/test_dataset_anomalous.py
@@ -116,18 +116,19 @@ def test_stack_anomalous_non_suffixes(data_merged, label_dict, suffixes):
     assert "I" not in result.columns
     assert "I_foo" not in result.columns
 
+
 def test_stack_anomalous_duplicates(data_merged):
     """
     Test DataSet.stack_anomalous() raises ValueError if stacking will result
     in duplicate column names
     """
-    
-    rename_dict = {"IMEAN" : "I"}
+
+    rename_dict = {"IMEAN": "I"}
     data_duplicates = data_merged.rename(columns=rename_dict)
-    
+
     with pytest.raises(ValueError):
         data_duplicates.stack_anomalous()
-    
+
 
 def test_stack_anomalous_unmerged(data_unmerged):
     """

--- a/tests/test_dataset_anomalous.py
+++ b/tests/test_dataset_anomalous.py
@@ -57,7 +57,7 @@ def test_stack_anomalous_failure(data_merged, plus_labels, minus_labels, suffixe
     Test that DataSet.stack_anomalous() fails with improper arguments
     """
     with pytest.raises(ValueError):
-        result = data_merged.stack_anomalous(plus_labels, minus_labels, suffixes)
+        data_merged.stack_anomalous(plus_labels, minus_labels, suffixes)
 
 
 @pytest.mark.parametrize(
@@ -116,13 +116,25 @@ def test_stack_anomalous_non_suffixes(data_merged, label_dict, suffixes):
     assert "I" not in result.columns
     assert "I_foo" not in result.columns
 
+def test_stack_anomalous_duplicates(data_merged):
+    """
+    Test DataSet.stack_anomalous() raises ValueError if stacking will result
+    in duplicate column names
+    """
+    
+    rename_dict = {"IMEAN" : "I"}
+    data_duplicates = data_merged.rename(columns=rename_dict)
+    
+    with pytest.raises(ValueError):
+        data_duplicates.stack_anomalous()
+    
 
 def test_stack_anomalous_unmerged(data_unmerged):
     """
     Test DataSet.stack_anomalous() raises ValueError with unmerged data
     """
     with pytest.raises(ValueError):
-        result = data_unmerged.stack_anomalous()
+        data_unmerged.stack_anomalous()
 
 
 @pytest.mark.parametrize("columns", [None, "I", ["I", "SIGI"], ("I", "SIGI"), 5])
@@ -135,7 +147,7 @@ def test_unstack_anomalous(data_merged, columns, suffixes):
 
     def check_ValueError(data, columns, suffixes):
         with pytest.raises(ValueError):
-            result = data.unstack_anomalous(columns, suffixes)
+            data.unstack_anomalous(columns, suffixes)
         return
 
     # Test input validation
@@ -163,7 +175,7 @@ def test_unstack_anomalous_unmerged(data_unmerged):
     Test DataSet.unstack_anomalous() raises ValueError with unmerged data
     """
     with pytest.raises(ValueError):
-        result = data_unmerged.unstack_anomalous()
+        data_unmerged.unstack_anomalous()
 
 
 @pytest.mark.parametrize("rangeindexed", [True, False])


### PR DESCRIPTION
This was pretty straightforward. Now, if you attempt to call `DataSet.stack_anomalous()` on a dataset containing columns such as `I`, `I(+)`, and `I(-)`, you are greeted with the error message:
```
ValueError: Stacking anomalous data will result in duplicate column names. Rename or drop column 'I' and try again.
```
I also added `test_stack_anomalous_duplicates()` to `test_dataset_anomalous.py` to verify this behavior.

### Minor reordering
In the previous version of `DataSet.stack_anomalous()`, the line:
```python
new_labels = [l.rstrip(suffixes[0]) for l in plus_labels]
```
comes after the following:
```python
centrics = self.label_centrics()["CENTRIC"]
dataset_plus = self.drop(columns=list(minus_labels))
dataset_minus = self.loc[~centrics].drop(columns=list(plus_labels))
dataset_minus.apply_symop(gemmi.Op("-x,-y,-z"), inplace=True)
```
I was concerned that if I didn't check for bad labels until these four lines had already been run, that when the function exits with an error, the `DataSet` might still get modified without the user realizing? I'm not entirely sure if that's how things work, but in any event, I reordered things. Now, the labels are checked for potential duplicates *before* the `DataSet` is modified.

#### A random and annoying thing that I changed
Spyder astutely pointed out to me that several tests in `test_dataset_anomalous.py` contained things like:
```python
with pytest.raises(ValueError):
    result = data_unmerged.unstack_anomalous()
```
but never actually access the `result`. I changed these instances to
```python
with pytest.raises(ValueError):
    data_unmerged.unstack_anomalous()
```
etc. This is totally unrelated to this PR, so I'm happy to take this out if making this change here is annoying for code/version organization purposes.