### PR TITLE
Allow integer-backed columns with NaNs to be converted to float dtype

### DIFF
--- a/tests/dtypes/test_dtypes.py
+++ b/tests/dtypes/test_dtypes.py
@@ -57,6 +57,32 @@ def test_to_numpy_nan(data_int, with_nan):
         assert result.dtype.name == "int32"
 
 
+@pytest.mark.parametrize("with_nan", [True, False])
+def test_int_to_float_withNan(data_int, with_nan):
+    """
+    Test int32-backed ExtensionArray to_numpy(np.float32) method. Should return
+    float32 regardless of whether it contains a NaN.
+    """
+    if with_nan:
+        data_int[10] = data_int._na_value
+
+    result = data_int.to_numpy(np.float32)
+    assert result.dtype.name == "float32"
+
+
+@pytest.mark.parametrize("with_nan", [True, False])
+def test_float_to_float_withNan(data_float, with_nan):
+    """
+    Test float32-backed ExtensionArray to_numpy() method. Should return
+    float32 regardless of whether it contains a NaN.
+    """
+    if with_nan:
+        data_float[10] = data_float._na_value
+
+    result = data_float.to_numpy()
+    assert result.dtype.name == "float32"
+
+
 def test_is_friedel_dtype(dtype_all):
     """Test MTZDtype.is_friedel_dtype()"""
     expected = rs.DataSeries(np.arange(0, 100), dtype=dtype_all[0]())

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,6 @@
 import gemmi
 import numpy as np
+import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
@@ -629,3 +630,16 @@ def test_is_isomorphous(data_unmerged, data_fmodel, sg1, sg2, cell1, cell2):
             assert result
         else:
             assert not result
+
+
+def test_to_gemmi_withNans(data_merged):
+    """
+    GH144: Test whether DataSet.to_gemmi() works with NaN-containing data.
+
+    This test is intended to ensure DataSet works as intended with Phenix
+    output, which often has many NaNs from filled reflections.
+    """
+    data_merged.loc[data_merged.index[0], "N(+)"] = np.nan
+    roundtrip = rs.DataSet.from_gemmi(data_merged.to_gemmi())
+
+    assert pd.isna(roundtrip.loc[data_merged.index[0], "N(+)"])


### PR DESCRIPTION
This PR addresses #144, allowing integer-backed column types containing NaNs to be converted to float ndarrays.

Importantly, this ensures that phenix output MTZs can be "round-trip" read/written, and converted to/from `gemmi`