### PR TITLE
Update documentation links to CCP4 MTZ column-types

### DIFF
--- a/docs/userguide/mtzdtypes.ipynb
+++ b/docs/userguide/mtzdtypes.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# MTZ Data Types  \n",
     "\n",
-    "MTZ files use column types to specify what type of crystallographic data is contained within a given column (see [MTZ specification](http://www.ccp4.ac.uk/html/mtzformat.html#coltypes)). This enables columns to have arbitrary names while ensuring that the column values are interpreted correctly.  \n",
+    "MTZ files use column types to specify what type of crystallographic data is contained within a given column (see [MTZ specification](https://www.ccp4.ac.uk/html/mtzformat.html#column-types)). This enables columns to have arbitrary names while ensuring that the column values are interpreted correctly.  \n",
     "\n",
     "In order to ensure that MTZ data types behave as expected in ``rs.DataSet`` objects, we have implemented a set of custom ``pandas`` dtypes to represent the crystallographic data found in MTZ files. This facilitates MTZ file I/O, and makes it possible to write methods that operate only on expected types of crystallographic data. "
    ]
@@ -515,9 +515,9 @@
     {
      "data": {
       "text/plain": [
-       "0    0\n",
-       "1    1\n",
-       "2    2\n",
+       "0   0\n",
+       "1   1\n",
+       "2   2\n",
        "dtype: MTZInt"
       ]
      },
@@ -624,16 +624,16 @@
    "outputs": [
     {
      "ename": "ValueError",
-     "evalue": "column of type object cannot be written to an MTZ file. To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True",
+     "evalue": "column Temp of type object cannot be written to an MTZ file. To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-18-34c859a707fe>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdataset\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite_mtz\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"temp.mtz\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/anaconda2/envs/rs/lib/python3.7/site-packages/reciprocalspaceship-0.8.2-py3.7.egg/reciprocalspaceship/dataset.py\u001b[0m in \u001b[0;36mwrite_mtz\u001b[0;34m(self, mtzfile, skip_problem_mtztypes)\u001b[0m\n\u001b[1;32m    178\u001b[0m         \"\"\"\n\u001b[1;32m    179\u001b[0m         \u001b[0;32mfrom\u001b[0m \u001b[0mreciprocalspaceship\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mio\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 180\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite_mtz\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmtzfile\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mskip_problem_mtztypes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    181\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    182\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mget_phase_keys\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda2/envs/rs/lib/python3.7/site-packages/reciprocalspaceship-0.8.2-py3.7.egg/reciprocalspaceship/io/mtz.py\u001b[0m in \u001b[0;36mwrite_mtz\u001b[0;34m(dataset, mtzfile, skip_problem_mtztypes)\u001b[0m\n\u001b[1;32m    112\u001b[0m         \u001b[0mMTZ\u001b[0m \u001b[0mdatatypes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    113\u001b[0m     \"\"\"\n\u001b[0;32m--> 114\u001b[0;31m     \u001b[0mmtz\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mto_gemmi\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mskip_problem_mtztypes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    115\u001b[0m     \u001b[0mmtz\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite_to_file\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmtzfile\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    116\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda2/envs/rs/lib/python3.7/site-packages/reciprocalspaceship-0.8.2-py3.7.egg/reciprocalspaceship/io/mtz.py\u001b[0m in \u001b[0;36mto_gemmi\u001b[0;34m(dataset, skip_problem_mtztypes)\u001b[0m\n\u001b[1;32m     80\u001b[0m             \u001b[0;32mcontinue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 82\u001b[0;31m             raise ValueError(f\"column of type {cseries.dtype} cannot be written to an MTZ file. \"\n\u001b[0m\u001b[1;32m     83\u001b[0m                              f\"To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True\")\n\u001b[1;32m     84\u001b[0m     \u001b[0mmtz\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_data\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtemp\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcolumns\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_numpy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"float32\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: column of type object cannot be written to an MTZ file. To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True"
+      "\u001b[0;32m/var/folders/hd/0z53c0y171l7xz7kl4vqmtgc0000gp/T/ipykernel_7958/2127968585.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdataset\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite_mtz\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"temp.mtz\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Documents/Hekstra_Lab/github/reciprocalspaceship/reciprocalspaceship/dataset.py\u001b[0m in \u001b[0;36mwrite_mtz\u001b[0;34m(self, mtzfile, skip_problem_mtztypes)\u001b[0m\n\u001b[1;32m    536\u001b[0m         \u001b[0;32mfrom\u001b[0m \u001b[0mreciprocalspaceship\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mio\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    537\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 538\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite_mtz\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmtzfile\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mskip_problem_mtztypes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    539\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    540\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mget_phase_keys\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/Hekstra_Lab/github/reciprocalspaceship/reciprocalspaceship/io/mtz.py\u001b[0m in \u001b[0;36mwrite_mtz\u001b[0;34m(dataset, mtzfile, skip_problem_mtztypes)\u001b[0m\n\u001b[1;32m    181\u001b[0m         \u001b[0mMTZ\u001b[0m \u001b[0mdatatypes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    182\u001b[0m     \"\"\"\n\u001b[0;32m--> 183\u001b[0;31m     \u001b[0mmtz\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mto_gemmi\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mskip_problem_mtztypes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    184\u001b[0m     \u001b[0mmtz\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite_to_file\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmtzfile\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    185\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/Hekstra_Lab/github/reciprocalspaceship/reciprocalspaceship/io/mtz.py\u001b[0m in \u001b[0;36mto_gemmi\u001b[0;34m(dataset, skip_problem_mtztypes)\u001b[0m\n\u001b[1;32m    120\u001b[0m             \u001b[0;32mcontinue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    121\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 122\u001b[0;31m             raise ValueError(\n\u001b[0m\u001b[1;32m    123\u001b[0m                 \u001b[0;34mf\"column {c} of type {cseries.dtype} cannot be written to an MTZ file. \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    124\u001b[0m                 \u001b[0;34mf\"To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: column Temp of type object cannot be written to an MTZ file. To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True"
      ]
     }
    ],
@@ -660,7 +660,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -674,7 +674,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/reciprocalspaceship/dtypes/summarize.py
+++ b/reciprocalspaceship/dtypes/summarize.py
@@ -12,7 +12,7 @@ def summarize_mtz_dtypes(print_summary=True):
     compatibility with the different column types supported by the
     `MTZ file specification`_.
 
-    .. _MTZ file specification: http://legacy.ccp4.ac.uk/html/mtzformat.html#coltypes
+    .. _MTZ file specification: https://www.ccp4.ac.uk/html/mtzformat.html#column-types
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes #141 -- updates broken URL in documentation and `rs.summarize_mtz_dtypes()` docstring