### PR TITLE
Add `DataSet.select_mtzdtype()` to subset `DataSet` by MTZ column type

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -564,7 +564,14 @@ class DataSet(pd.DataFrame):
         elif isinstance(dtype, str):
             # One-letter code
             if len(dtype) == 1:
-                return self[[k for k in self if self[k].dtype.mtztype == dtype]]
+                return self[
+                    [
+                        k
+                        for k in self
+                        if hasattr(self[k].dtype, "mtztype")
+                        and self[k].dtype.mtztype == dtype
+                    ]
+                ]
             else:
                 return self[[k for k in self if self[k].dtype.name == dtype]]
         raise ValueError(

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -11,6 +11,7 @@ from reciprocalspaceship.decorators import (
     range_indexed,
     spacegroupify,
 )
+from reciprocalspaceship.dtypes.base import MTZDtype
 from reciprocalspaceship.utils import (
     apply_to_hkl,
     bin_by_percentile,
@@ -536,6 +537,37 @@ class DataSet(pd.DataFrame):
         from reciprocalspaceship import io
 
         return io.write_mtz(self, mtzfile, skip_problem_mtztypes)
+
+    def select_mtzdtype(self, dtype):
+        """
+        Return the subset of the DataSet’s columns that are of the given dtype.
+
+        Parameters
+        ----------
+        dtype : str or instance of MTZDtype class
+            Single-letter MTZ code, name, or MTZDtype class to return
+
+        Returns
+        -------
+        DataSet
+            Subset of the DataSet with columns matching the requested dtype. If
+            no columns of the requested dtype are found, an empty DataSet is
+            returned.
+
+        Raises
+        ------
+        ValueError
+            If `dtype` is not a string nor a MTZDtype class
+        """
+        if isinstance(dtype, MTZDtype):
+            return self[[k for k in self if isinstance(self.dtypes[k], type(dtype))]]
+        elif isinstance(dtype, str):
+            # One-letter code
+            if len(dtype) == 1:
+                return self[[k for k in self if self[k].dtype.mtztype == dtype]]
+            else:
+                return self[[k for k in self if self[k].dtype.name == dtype]]
+        raise ValueError(f"dtype must be a str or MTZDtype class. Called with: {dtype}")
 
     def get_phase_keys(self):
         """

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -567,7 +567,9 @@ class DataSet(pd.DataFrame):
                 return self[[k for k in self if self[k].dtype.mtztype == dtype]]
             else:
                 return self[[k for k in self if self[k].dtype.name == dtype]]
-        raise ValueError(f"dtype must be a str or MTZDtype class. Called with: {dtype}")
+        raise ValueError(
+            f"dtype must be a str or MTZDtype instance. Called with: {dtype}"
+        )
 
     def get_phase_keys(self):
         """

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -540,12 +540,12 @@ class DataSet(pd.DataFrame):
 
     def select_mtzdtype(self, dtype):
         """
-        Return the subset of the DataSet’s columns that are of the given dtype.
+        Return subset of DataSet’s columns that are of the given dtype.
 
         Parameters
         ----------
-        dtype : str or instance of MTZDtype class
-            Single-letter MTZ code, name, or MTZDtype class to return
+        dtype : str or instance of MTZDtype
+            Single-letter MTZ code, name, or MTZDtype instance to return
 
         Returns
         -------
@@ -557,7 +557,7 @@ class DataSet(pd.DataFrame):
         Raises
         ------
         ValueError
-            If `dtype` is not a string nor a MTZDtype class
+            If `dtype` is not a string nor a MTZDtype instance
         """
         if isinstance(dtype, MTZDtype):
             return self[[k for k in self if isinstance(self.dtypes[k], type(dtype))]]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -649,7 +649,7 @@ def test_to_gemmi_withNans(data_merged):
     "dtype",
     rs.summarize_mtz_dtypes(False)[["MTZ Code", "Name", "Class"]].melt().itertuples(),
 )
-def test_select_mtzdtype(data_merged, dtype):
+def test_select_mtzdtype(data_hewl, dtype):
     """
     Test DataSet.select_mtzdtype() with MTZDtype class, MTZ code, and dtype name
     """
@@ -660,23 +660,29 @@ def test_select_mtzdtype(data_merged, dtype):
 
         return getattr(sys.modules["reciprocalspaceship"], classname)
 
-    d = data_merged.copy()
+    d = data_hewl.copy()
     if dtype.variable == "MTZ Code":
         dtype = dtype.value
-        expected = d[[k for k in d if d[k].dtype.mtztype == dtype]]
-        result = data_merged.select_mtzdtype(dtype)
+        expected = d[
+            [
+                k
+                for k in d
+                if hasattr(d[k].dtype, "mtztype") and d[k].dtype.mtztype == dtype
+            ]
+        ]
+        result = data_hewl.select_mtzdtype(dtype)
     elif dtype.variable == "Name":
         dtype = dtype.value
         expected = d[[k for k in d if d[k].dtype.name == dtype]]
-        result = data_merged.select_mtzdtype(dtype)
+        result = data_hewl.select_mtzdtype(dtype)
     else:
         dtype = _str_to_class(dtype.value)
         expected = d[[k for k in d if isinstance(d[k].dtype, dtype)]]
-        result = data_merged.select_mtzdtype(dtype())
+        result = data_hewl.select_mtzdtype(dtype())
 
     assert_frame_equal(result, expected)
-    assert result.spacegroup.xhm() == data_merged.spacegroup.xhm()
-    assert np.array_equal(result.cell.parameters, data_merged.cell.parameters)
+    assert result.spacegroup.xhm() == data_hewl.spacegroup.xhm()
+    assert np.array_equal(result.cell.parameters, data_hewl.cell.parameters)
 
 
 @pytest.mark.parametrize("dtype", [1, 1.0, pd.Int32Dtype()])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -643,3 +643,47 @@ def test_to_gemmi_withNans(data_merged):
     roundtrip = rs.DataSet.from_gemmi(data_merged.to_gemmi())
 
     assert pd.isna(roundtrip.loc[data_merged.index[0], "N(+)"])
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    rs.summarize_mtz_dtypes(False)[["MTZ Code", "Name", "Class"]].melt().itertuples(),
+)
+def test_select_mtzdtype(data_merged, dtype):
+    """
+    Test DataSet.select_mtzdtype() with MTZDtype class, MTZ code, and dtype name
+    """
+
+    def _str_to_class(classname):
+        """Convert string of class into instance of class"""
+        import sys
+
+        return getattr(sys.modules["reciprocalspaceship"], classname)
+
+    d = data_merged.copy()
+    if dtype.variable == "MTZ Code":
+        dtype = dtype.value
+        expected = d[[k for k in d if d[k].dtype.mtztype == dtype]]
+        result = data_merged.select_mtzdtype(dtype)
+    elif dtype.variable == "Name":
+        dtype = dtype.value
+        expected = d[[k for k in d if d[k].dtype.name == dtype]]
+        result = data_merged.select_mtzdtype(dtype)
+    else:
+        dtype = _str_to_class(dtype.value)
+        expected = d[[k for k in d if isinstance(d[k].dtype, dtype)]]
+        result = data_merged.select_mtzdtype(dtype())
+
+    assert_frame_equal(result, expected)
+    assert result.spacegroup.xhm() == data_merged.spacegroup.xhm()
+    assert np.array_equal(result.cell.parameters, data_merged.cell.parameters)
+
+
+@pytest.mark.parametrize("dtype", [1, 1.0, pd.Int32Dtype()])
+def test_select_mtzdtype_ValueError(data_merged, dtype):
+    """
+    Test DataSet.select_mtzdtype() raises ValueError if `dtype` is not a
+    string nor MTZDtype instance.
+    """
+    with pytest.raises(ValueError):
+        data_merged.select_mtzdtype(dtype)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -649,7 +649,8 @@ def test_to_gemmi_withNans(data_merged):
     "dtype",
     rs.summarize_mtz_dtypes(False)[["MTZ Code", "Name", "Class"]].melt().itertuples(),
 )
-def test_select_mtzdtype(data_hewl, dtype):
+@pytest.mark.parametrize("reset_index", [True, False])
+def test_select_mtzdtype(data_hewl, dtype, reset_index):
     """
     Test DataSet.select_mtzdtype() with MTZDtype class, MTZ code, and dtype name
     """
@@ -659,6 +660,10 @@ def test_select_mtzdtype(data_hewl, dtype):
         import sys
 
         return getattr(sys.modules["reciprocalspaceship"], classname)
+
+    # If True, remove HKL from index:
+    if reset_index:
+        data_hewl.reset_index(inplace=True)
 
     d = data_hewl.copy()
     if dtype.variable == "MTZ Code":


### PR DESCRIPTION
This PR adds a new function to `DataSet`, `select_mtzdtype()`:
```python
In [1]: rs.DataSet.select_mtzdtype?
Signature: rs.DataSet.select_mtzdtype(self, dtype)
Docstring:
Return the subset of the DataSet’s columns that are of the given dtype.

Parameters
----------
dtype : str or instance of MTZDtype class
    Single-letter MTZ code, name, or MTZDtype class to return

Returns
-------
DataSet
    Subset of the DataSet with columns matching the requested dtype. If
    no columns of the requested dtype are found, an empty DataSet is
    returned.

Raises
------
ValueError
    If `dtype` is not a string nor a MTZDtype class
File:      ~/Documents/Hekstra_Lab/github/reciprocalspaceship/reciprocalspaceship/dataset.py
Type:      function
```

This PR fixes #104, making it easier to subset a `DataSet` to columns of a desired MTZ column type. 