### PR TITLE
Add function to convert structure factor amplitudes to intensities to `algorithms` submodule

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -57,6 +57,7 @@ Algorithms for processing reflection data stored in ``rs.DataSet`` objects.
 
    ~reciprocalspaceship.algorithms.merge
    ~reciprocalspaceship.algorithms.scale_merged_intensities
+   ~reciprocalspaceship.algorithms.compute_intensity_from_structurefactor
 
 Summary Statistics
 ------------------

--- a/reciprocalspaceship/algorithms/__init__.py
+++ b/reciprocalspaceship/algorithms/__init__.py
@@ -2,3 +2,6 @@ from reciprocalspaceship.algorithms.merge import merge
 from reciprocalspaceship.algorithms.scale_merged_intensities import (
     scale_merged_intensities,
 )
+from reciprocalspaceship.algorithms.intensity import (
+    compute_intensity_from_structurefactor,
+)

--- a/reciprocalspaceship/algorithms/__init__.py
+++ b/reciprocalspaceship/algorithms/__init__.py
@@ -1,7 +1,7 @@
+from reciprocalspaceship.algorithms.intensity import (
+    compute_intensity_from_structurefactor,
+)
 from reciprocalspaceship.algorithms.merge import merge
 from reciprocalspaceship.algorithms.scale_merged_intensities import (
     scale_merged_intensities,
-)
-from reciprocalspaceship.algorithms.intensity import (
-    compute_intensity_from_structurefactor,
 )

--- a/reciprocalspaceship/algorithms/intensity.py
+++ b/reciprocalspaceship/algorithms/intensity.py
@@ -1,7 +1,9 @@
+import warnings
+
 import numpy as np
 
 import reciprocalspaceship as rs
-import warnings
+
 
 def compute_intensity_from_structurefactor(
     ds,
@@ -14,7 +16,7 @@ def compute_intensity_from_structurefactor(
     """
     Back-calculate intensities and approximate intensity error estimates from
     structure factor amplitudes and error estimates
-    
+
     Intensity computed as I = SigF*SigF + F*F. Intensity error estimate
     approximated as SigI = abs(2*F*SigF)
 
@@ -41,7 +43,7 @@ def compute_intensity_from_structurefactor(
     DataSet
         DataSet with 2 additional columns corresponding to back-calculated
         intensities and intensity error estimates
-    
+
     """
 
     if not inplace:
@@ -56,32 +58,35 @@ def compute_intensity_from_structurefactor(
                 f"Input {ds.__class__.__name__} contains NaNs "
                 f"in columns '{F_key}' and/or '{SigF_key}'. "
                 f"Please fix these input values, or run with dropna=True"
-                )
-    
+            )
+
     if output_columns is None:
         output_columns = ["I_back", "SigI_back"]
-    I_key, SigI_key, = output_columns
+    (
+        I_key,
+        SigI_key,
+    ) = output_columns
 
     if I_key in ds.columns:
         raise ValueError(
             f"Input {ds.__class__.__name__} already contains column '{I_key}'."
             f"Try again and use the output_columns argument to pick a new"
             f"output column name."
-            )
+        )
     if SigI_key in ds.columns:
         raise ValueError(
             f"Input {ds.__class__.__name__} already contains column '{SigI_key}'."
             f"Try again and use the output_columns argument to pick a new"
             f"output column name."
-            )
-    
+        )
+
     # Initialize outputs
     ds[I_key] = 0.0
     ds[SigI_key] = 0.0
-    
+
     F_np = ds[F_key].to_numpy()
     SigF_np = ds[SigF_key].to_numpy()
-    
+
     I = SigF_np * SigF_np + F_np * F_np
     SigI = np.abs(2 * F_np * SigF_np)
 

--- a/reciprocalspaceship/algorithms/intensity.py
+++ b/reciprocalspaceship/algorithms/intensity.py
@@ -1,19 +1,19 @@
 import numpy as np
 
 import reciprocalspaceship as rs
+from reciprocalspaceship.decorators import inplace
 
-
+@inplace
 def compute_intensity_from_structurefactor(
     ds,
     F_key,
     SigF_key,
     output_columns=None,
-    dropna=True,
     inplace=False,
 ):
     """
-    Back-calculate intensities and approximate intensity error estimates from
-    structure factor amplitudes and error estimates
+    Compute intensities (I) and uncertainty estimates (SigI) from structure 
+    factor amplitudes (F) and their uncertainties (SigF) using error propagation
 
     Intensity computed as I = SigF*SigF + F*F. Intensity error estimate
     approximated as SigI = abs(2*F*SigF)
@@ -23,43 +23,36 @@ def compute_intensity_from_structurefactor(
     ds : DataSet
         Input DataSet containing columns with F_key and SigF_key labels
     F_key : str
-        Column label for structure factor amplitudes to use in back-calculation
+        Column label for structure factor amplitudes
     SigF_key : str
-        Column label for structure factor error estimates to use in
-        back-calculation
+        Column label for structure factor error estimates
     output_columns : list or tuple of column names
-        Column labels to be added to ds for recording back-calculated I and
+        Column labels to be added to ds for calculated I and
         SigI, respectively. output_columns must have len=2.
-    dropna : bool
-        Whether to drop reflections with NaNs in F_key or SigF_key
-        columns
     inplace : bool
         Whether to modify the DataSet in place or create a copy
 
     Returns
     -------
     DataSet
-        DataSet with 2 additional columns corresponding to back-calculated
+        DataSet with 2 additional columns corresponding to calculated
         intensities and intensity error estimates
 
     """
 
-    if not inplace:
-        ds = ds.copy()
-
     # Sanitize input or check for invalid reflections
-    if dropna:
-        ds.dropna(subset=[F_key, SigF_key], inplace=True)
-    else:
-        if ds[[F_key, SigF_key]].isna().to_numpy().any():
-            raise ValueError(
-                f"Input {ds.__class__.__name__} contains NaNs "
-                f"in columns '{F_key}' and/or '{SigF_key}'. "
-                f"Please fix these input values, or run with dropna=True"
-            )
+    # if dropna:
+    #     ds.dropna(subset=[F_key, SigF_key], inplace=True)
+    # else:
+    #     if ds[[F_key, SigF_key]].isna().to_numpy().any():
+    #         raise ValueError(
+    #             f"Input {ds.__class__.__name__} contains NaNs "
+    #             f"in columns '{F_key}' and/or '{SigF_key}'. "
+    #             f"Please fix these input values, or run with dropna=True"
+    #         )
 
     if output_columns is None:
-        output_columns = ["I_back", "SigI_back"]
+        output_columns = ["I_calc", "SigI_calc"]
     (
         I_key,
         SigI_key,
@@ -79,16 +72,14 @@ def compute_intensity_from_structurefactor(
         )
 
     # Initialize outputs
-    ds[I_key] = 0.0
-    ds[SigI_key] = 0.0
-
-    F_np = ds[F_key].to_numpy()
-    SigF_np = ds[SigF_key].to_numpy()
-
-    I = SigF_np * SigF_np + F_np * F_np
-    SigI = np.abs(2 * F_np * SigF_np)
-
-    ds[I_key] = rs.DataSeries(I, index=ds.index, dtype="Intensity")
-    ds[SigI_key] = rs.DataSeries(SigI, index=ds.index, dtype="Stddev")
+    ds[I_key] = (
+        (ds[F_key]*ds[F_key] + ds[SigF_key]*ds[SigF_key])
+        .astype("Intensity")
+        )
+    ds[SigI_key] = (
+        (2*ds[F_key]*ds[SigF_key])
+        .abs()
+        .astype("Stddev")
+        )
 
     return ds

--- a/reciprocalspaceship/algorithms/intensity.py
+++ b/reciprocalspaceship/algorithms/intensity.py
@@ -41,17 +41,6 @@ def compute_intensity_from_structurefactor(
 
     """
 
-    # Sanitize input or check for invalid reflections
-    # if dropna:
-    #     ds.dropna(subset=[F_key, SigF_key], inplace=True)
-    # else:
-    #     if ds[[F_key, SigF_key]].isna().to_numpy().any():
-    #         raise ValueError(
-    #             f"Input {ds.__class__.__name__} contains NaNs "
-    #             f"in columns '{F_key}' and/or '{SigF_key}'. "
-    #             f"Please fix these input values, or run with dropna=True"
-    #         )
-
     if output_columns is None:
         output_columns = ["I_calc", "SigI_calc"]
     (
@@ -72,6 +61,18 @@ def compute_intensity_from_structurefactor(
             f"output column name."
         )
 
+    # Confirm F_key and SigF_key are of the correct dtype
+    if not isinstance(ds.dtypes[F_key], rs.StructureFactorAmplitudeDtype):
+        raise ValueError(
+            f"Column {F_key} is not of type rs.StructureFactorAmplitudeDtype."
+            f"Try again and provide structure factor amplitudes for F_key"
+            )
+    if not isinstance(ds.dtypes[SigF_key], rs.StandardDeviationDtype):
+        raise ValueError(
+            f"Column {SigF_key} is not of type rs.StandardDeviationDtype."
+            f"Try again and provide standard deviations for SigF_key"
+            )
+    
     # Initialize outputs
     ds[I_key] = (ds[F_key] * ds[F_key] + ds[SigF_key] * ds[SigF_key]).astype(
         "Intensity"

--- a/reciprocalspaceship/algorithms/intensity.py
+++ b/reciprocalspaceship/algorithms/intensity.py
@@ -3,6 +3,7 @@ import numpy as np
 import reciprocalspaceship as rs
 from reciprocalspaceship.decorators import inplace
 
+
 @inplace
 def compute_intensity_from_structurefactor(
     ds,
@@ -12,7 +13,7 @@ def compute_intensity_from_structurefactor(
     inplace=False,
 ):
     """
-    Compute intensities (I) and uncertainty estimates (SigI) from structure 
+    Compute intensities (I) and uncertainty estimates (SigI) from structure
     factor amplitudes (F) and their uncertainties (SigF) using error propagation
 
     Intensity computed as I = SigF*SigF + F*F. Intensity error estimate
@@ -72,14 +73,9 @@ def compute_intensity_from_structurefactor(
         )
 
     # Initialize outputs
-    ds[I_key] = (
-        (ds[F_key]*ds[F_key] + ds[SigF_key]*ds[SigF_key])
-        .astype("Intensity")
-        )
-    ds[SigI_key] = (
-        (2*ds[F_key]*ds[SigF_key])
-        .abs()
-        .astype("Stddev")
-        )
+    ds[I_key] = (ds[F_key] * ds[F_key] + ds[SigF_key] * ds[SigF_key]).astype(
+        "Intensity"
+    )
+    ds[SigI_key] = (2 * ds[F_key] * ds[SigF_key]).abs().astype("Stddev")
 
     return ds

--- a/reciprocalspaceship/algorithms/intensity.py
+++ b/reciprocalspaceship/algorithms/intensity.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 import reciprocalspaceship as rs

--- a/reciprocalspaceship/algorithms/intensity.py
+++ b/reciprocalspaceship/algorithms/intensity.py
@@ -1,0 +1,91 @@
+import numpy as np
+
+import reciprocalspaceship as rs
+import warnings
+
+def compute_intensity_from_structurefactor(
+    ds,
+    F_key,
+    SigF_key,
+    output_columns=None,
+    dropna=True,
+    inplace=False,
+):
+    """
+    Back-calculate intensities and approximate intensity error estimates from
+    structure factor amplitudes and error estimates
+    
+    Intensity computed as I = SigF*SigF + F*F. Intensity error estimate
+    approximated as SigI = abs(2*F*SigF)
+
+    Parameters
+    ----------
+    ds : DataSet
+        Input DataSet containing columns with F_key and SigF_key labels
+    F_key : str
+        Column label for structure factor amplitudes to use in back-calculation
+    SigF_key : str
+        Column label for structure factor error estimates to use in
+        back-calculation
+    output_columns : list or tuple of column names
+        Column labels to be added to ds for recording back-calculated I and
+        SigI, respectively. output_columns must have len=2.
+    dropna : bool
+        Whether to drop reflections with NaNs in F_key or SigF_key
+        columns
+    inplace : bool
+        Whether to modify the DataSet in place or create a copy
+
+    Returns
+    -------
+    DataSet
+        DataSet with 2 additional columns corresponding to back-calculated
+        intensities and intensity error estimates
+    
+    """
+
+    if not inplace:
+        ds = ds.copy()
+
+    # Sanitize input or check for invalid reflections
+    if dropna:
+        ds.dropna(subset=[F_key, SigF_key], inplace=True)
+    else:
+        if ds[[F_key, SigF_key]].isna().to_numpy().any():
+            raise ValueError(
+                f"Input {ds.__class__.__name__} contains NaNs "
+                f"in columns '{F_key}' and/or '{SigF_key}'. "
+                f"Please fix these input values, or run with dropna=True"
+                )
+    
+    if output_columns is None:
+        output_columns = ["I_back", "SigI_back"]
+    I_key, SigI_key, = output_columns
+
+    if I_key in ds.columns:
+        raise ValueError(
+            f"Input {ds.__class__.__name__} already contains column '{I_key}'."
+            f"Try again and use the output_columns argument to pick a new"
+            f"output column name."
+            )
+    if SigI_key in ds.columns:
+        raise ValueError(
+            f"Input {ds.__class__.__name__} already contains column '{SigI_key}'."
+            f"Try again and use the output_columns argument to pick a new"
+            f"output column name."
+            )
+    
+    # Initialize outputs
+    ds[I_key] = 0.0
+    ds[SigI_key] = 0.0
+    
+    F_np = ds[F_key].to_numpy()
+    SigF_np = ds[SigF_key].to_numpy()
+    
+    I = SigF_np * SigF_np + F_np * F_np
+    SigI = np.abs(2 * F_np * SigF_np)
+
+    ds[I_key] = rs.DataSeries(I, index=ds.index, dtype="Intensity")
+    ds[SigI_key] = rs.DataSeries(SigI, index=ds.index, dtype="Stddev")
+
+    return ds

--- a/tests/algorithms/test_intensity.py
+++ b/tests/algorithms/test_intensity.py
@@ -5,9 +5,7 @@ import reciprocalspaceship as rs
 
 
 @pytest.mark.parametrize("inplace", [True, False])
-@pytest.mark.parametrize("output_columns", [None, 
-                                            ("I_backcalc", "SigI_backcalc")]
-                         )
+@pytest.mark.parametrize("output_columns", [None, ("I_backcalc", "SigI_backcalc")])
 def test_compute_intensity_from_structurefactor(ref_hewl, inplace, output_columns):
     """
     Test rs.algorithms.compute_intensity_from_structurefactor() returns
@@ -15,45 +13,40 @@ def test_compute_intensity_from_structurefactor(ref_hewl, inplace, output_column
     """
 
     result = rs.algorithms.compute_intensity_from_structurefactor(
-        ref_hewl, 
-        "F",
-        "SIGF",
-        output_columns=output_columns,
-        inplace=inplace
+        ref_hewl, "F", "SIGF", output_columns=output_columns, inplace=inplace
     )
-    
+
     if inplace:
         assert id(result) == id(ref_hewl)
     else:
         assert id(result) != id(ref_hewl)
-     
+
     defaults = ("I_back", "SigI_back")
     if output_columns:
         o1, o2 = output_columns
     else:
         o1, o2 = defaults
-    
+
     # confirm types of new columns
     assert isinstance(result[o1].dtype, rs.IntensityDtype)
     assert isinstance(result[o2].dtype, rs.StandardDeviationDtype)
-    
+
     # confirm arithmetic
-    F = result['F'].to_numpy()
-    SigF = result['SIGF'].to_numpy()
+    F = result["F"].to_numpy()
+    SigF = result["SIGF"].to_numpy()
     I = result[o1].to_numpy()
     SigI = result[o2].to_numpy()
     assert np.isclose(I, SigF * SigF + F * F).all()
     assert np.isclose(SigI, np.abs(2 * F * SigF)).all()
+
 
 def test_compute_intensity_from_structurefactor_failure(ref_hewl):
     """
     Test that rs.algorithms.compute_intensity_from_structurefactor() throws a
     ValueError rather than overwriting columns
     """
-    
+
     with pytest.raises(ValueError):
         rs.algorithms.compute_intensity_from_structurefactor(
-            ref_hewl, 
-            'F', 
-            'SIGF',
-            output_columns=('I', 'SIGI'))
+            ref_hewl, "F", "SIGF", output_columns=("I", "SIGI")
+        )

--- a/tests/algorithms/test_intensity.py
+++ b/tests/algorithms/test_intensity.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+import reciprocalspaceship as rs
+
+
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("output_columns", [None, 
+                                            ("I_backcalc", "SigI_backcalc")]
+                         )
+def test_compute_intensity_from_structurefactor(ref_hewl, inplace, output_columns):
+    """
+    Test rs.algorithms.compute_intensity_from_structurefactor() returns
+    intensities and intensity error estimates as expected based on assumptions
+    """
+
+    result = rs.algorithms.compute_intensity_from_structurefactor(
+        ref_hewl, 
+        "F",
+        "SIGF",
+        output_columns=output_columns,
+        inplace=inplace
+    )
+    
+    if inplace:
+        assert id(result) == id(ref_hewl)
+    else:
+        assert id(result) != id(ref_hewl)
+     
+    defaults = ("I_back", "SigI_back")
+    if output_columns:
+        o1, o2 = output_columns
+    else:
+        o1, o2 = defaults
+    
+    # confirm types of new columns
+    assert isinstance(result[o1].dtype, rs.IntensityDtype)
+    assert isinstance(result[o2].dtype, rs.StandardDeviationDtype)
+    
+    # confirm arithmetic
+    F = result['F'].to_numpy()
+    SigF = result['SIGF'].to_numpy()
+    I = result[o1].to_numpy()
+    SigI = result[o2].to_numpy()
+    assert np.isclose(I, SigF * SigF + F * F).all()
+    assert np.isclose(SigI, np.abs(2 * F * SigF)).all()
+
+def test_compute_intensity_from_structurefactor_failure(ref_hewl):
+    """
+    Test that rs.algorithms.compute_intensity_from_structurefactor() throws a
+    ValueError rather than overwriting columns
+    """
+    
+    with pytest.raises(ValueError):
+        rs.algorithms.compute_intensity_from_structurefactor(
+            ref_hewl, 
+            'F', 
+            'SIGF',
+            output_columns=('I', 'SIGI'))

--- a/tests/algorithms/test_intensity.py
+++ b/tests/algorithms/test_intensity.py
@@ -60,11 +60,7 @@ def test_compute_intensity_from_structurefactor_failure(ref_hewl):
 
     # Function should require inputs of the correct types
     with pytest.raises(ValueError):
-        rs.algorithms.compute_intensity_from_structurefactor(
-            ref_hewl, "F", "F"
-        )
+        rs.algorithms.compute_intensity_from_structurefactor(ref_hewl, "F", "F")
 
     with pytest.raises(ValueError):
-        rs.algorithms.compute_intensity_from_structurefactor(
-            ref_hewl, "SIGF", "SIGF"
-        )
+        rs.algorithms.compute_intensity_from_structurefactor(ref_hewl, "SIGF", "SIGF")

--- a/tests/algorithms/test_intensity.py
+++ b/tests/algorithms/test_intensity.py
@@ -61,10 +61,10 @@ def test_compute_intensity_from_structurefactor_failure(ref_hewl):
     # Function should require inputs of the correct types
     with pytest.raises(ValueError):
         rs.algorithms.compute_intensity_from_structurefactor(
-            ref_hewl, "F", "F", output_columns=("I", "SIGI")
+            ref_hewl, "F", "F"
         )
 
     with pytest.raises(ValueError):
         rs.algorithms.compute_intensity_from_structurefactor(
-            ref_hewl, "SIGF", "SIGF", output_columns=("I", "SIGI")
+            ref_hewl, "SIGF", "SIGF"
         )

--- a/tests/algorithms/test_intensity.py
+++ b/tests/algorithms/test_intensity.py
@@ -5,12 +5,19 @@ import reciprocalspaceship as rs
 
 
 @pytest.mark.parametrize("inplace", [True, False])
-@pytest.mark.parametrize("output_columns", [None, ("I_backcalc", "SigI_backcalc")])
-def test_compute_intensity_from_structurefactor(ref_hewl, inplace, output_columns):
+@pytest.mark.parametrize("output_columns", [None, ("I_CALC", "SigI_CALC")])
+@pytest.mark.parametrize("test_na", [True, False])
+def test_compute_intensity_from_structurefactor(ref_hewl, 
+                                                inplace, 
+                                                output_columns, 
+                                                test_na):
     """
     Test rs.algorithms.compute_intensity_from_structurefactor() returns
     intensities and intensity error estimates as expected based on assumptions
     """
+
+    if test_na:  
+        ref_hewl.loc[0,0,4] = np.nan
 
     result = rs.algorithms.compute_intensity_from_structurefactor(
         ref_hewl, "F", "SIGF", output_columns=output_columns, inplace=inplace
@@ -21,7 +28,7 @@ def test_compute_intensity_from_structurefactor(ref_hewl, inplace, output_column
     else:
         assert id(result) != id(ref_hewl)
 
-    defaults = ("I_back", "SigI_back")
+    defaults = ("I_calc", "SigI_calc")
     if output_columns:
         o1, o2 = output_columns
     else:
@@ -36,8 +43,8 @@ def test_compute_intensity_from_structurefactor(ref_hewl, inplace, output_column
     SigF = result["SIGF"].to_numpy()
     I = result[o1].to_numpy()
     SigI = result[o2].to_numpy()
-    assert np.isclose(I, SigF * SigF + F * F).all()
-    assert np.isclose(SigI, np.abs(2 * F * SigF)).all()
+    assert np.allclose(I, SigF * SigF + F * F, equal_nan=True)
+    assert np.allclose(SigI, np.abs(2 * F * SigF), equal_nan=True)
 
 
 def test_compute_intensity_from_structurefactor_failure(ref_hewl):

--- a/tests/algorithms/test_intensity.py
+++ b/tests/algorithms/test_intensity.py
@@ -7,17 +7,16 @@ import reciprocalspaceship as rs
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("output_columns", [None, ("I_CALC", "SigI_CALC")])
 @pytest.mark.parametrize("test_na", [True, False])
-def test_compute_intensity_from_structurefactor(ref_hewl, 
-                                                inplace, 
-                                                output_columns, 
-                                                test_na):
+def test_compute_intensity_from_structurefactor(
+    ref_hewl, inplace, output_columns, test_na
+):
     """
     Test rs.algorithms.compute_intensity_from_structurefactor() returns
     intensities and intensity error estimates as expected based on assumptions
     """
 
-    if test_na:  
-        ref_hewl.loc[0,0,4] = np.nan
+    if test_na:
+        ref_hewl.loc[0, 0, 4] = np.nan
 
     result = rs.algorithms.compute_intensity_from_structurefactor(
         ref_hewl, "F", "SIGF", output_columns=output_columns, inplace=inplace

--- a/tests/algorithms/test_intensity.py
+++ b/tests/algorithms/test_intensity.py
@@ -48,11 +48,23 @@ def test_compute_intensity_from_structurefactor(
 
 def test_compute_intensity_from_structurefactor_failure(ref_hewl):
     """
-    Test that rs.algorithms.compute_intensity_from_structurefactor() throws a
-    ValueError rather than overwriting columns
+    Test that rs.algorithms.compute_intensity_from_structurefactor() throws
+    ValueErrors when appropriate
     """
 
+    # Function should not overwrite existing columns
     with pytest.raises(ValueError):
         rs.algorithms.compute_intensity_from_structurefactor(
             ref_hewl, "F", "SIGF", output_columns=("I", "SIGI")
+        )
+    
+    # Function should require inputs of the correct types
+    with pytest.raises(ValueError):
+        rs.algorithms.compute_intensity_from_structurefactor(
+            ref_hewl, "F", "F", output_columns=("I", "SIGI")
+        )
+
+    with pytest.raises(ValueError):
+        rs.algorithms.compute_intensity_from_structurefactor(
+            ref_hewl, "SIGF", "SIGF", output_columns=("I", "SIGI")
         )


### PR DESCRIPTION
Now with the desired `DataSet`-based API.

I ended up deciding to name the new columns `I_back` and `SigI_back` by default, and to raise a `ValueError` if the method would overwrite a column. Happy to be overruled on one or both of those.