### PR TITLE
Add interface for setting project, crystal, and dataset names

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -319,9 +319,9 @@ class DataSet(pd.DataFrame):
     def to_gemmi(
         self,
         skip_problem_mtztypes=False,
-        project_name=None,
-        crystal_name=None,
-        dataset_name=None,
+        project_name="reciprocalspaceship",
+        crystal_name="reciprocalspaceship",
+        dataset_name="reciprocalspaceship",
     ):
         """
         Creates gemmi.Mtz object from DataSet object.
@@ -489,9 +489,9 @@ class DataSet(pd.DataFrame):
         self,
         mtzfile,
         skip_problem_mtztypes=False,
-        project_name=None,
-        crystal_name=None,
-        dataset_name=None,
+        project_name="reciprocalspaceship",
+        crystal_name="reciprocalspaceship",
+        dataset_name="reciprocalspaceship",
     ):
         """
         Write DataSet to MTZ file.

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -316,7 +316,13 @@ class DataSet(pd.DataFrame):
         """
         return cls(gemmiMtz)
 
-    def to_gemmi(self, skip_problem_mtztypes=False):
+    def to_gemmi(
+        self,
+        skip_problem_mtztypes=False,
+        project_name=None,
+        crystal_name=None,
+        dataset_name=None,
+    ):
         """
         Creates gemmi.Mtz object from DataSet object.
 
@@ -332,6 +338,12 @@ class DataSet(pd.DataFrame):
         skip_problem_mtztypes : bool
             Whether to skip columns in DataSet that do not have specified
             MTZ datatypes
+        project_name : str
+            Project name to assign to MTZ file
+        crystal_name : str
+            Crystal name to assign to MTZ file
+        dataset_name : str
+            Dataset name to assign to MTZ file
 
         Returns
         -------
@@ -339,7 +351,9 @@ class DataSet(pd.DataFrame):
         """
         from reciprocalspaceship import io
 
-        return io.to_gemmi(self, skip_problem_mtztypes)
+        return io.to_gemmi(
+            self, skip_problem_mtztypes, project_name, crystal_name, dataset_name
+        )
 
     def to_pickle(self, path, *args, **kwargs):
         """
@@ -471,7 +485,14 @@ class DataSet(pd.DataFrame):
         result = super().join(*args, **kwargs)
         return result.__finalize__(self)
 
-    def write_mtz(self, mtzfile, skip_problem_mtztypes=False):
+    def write_mtz(
+        self,
+        mtzfile,
+        skip_problem_mtztypes=False,
+        project_name=None,
+        crystal_name=None,
+        dataset_name=None,
+    ):
         """
         Write DataSet to MTZ file.
 
@@ -489,10 +510,23 @@ class DataSet(pd.DataFrame):
         skip_problem_mtztypes : bool
             Whether to skip columns in DataSet that do not have specified
             MTZ datatypes
+        project_name : str
+            Project name to assign to MTZ file
+        crystal_name : str
+            Crystal name to assign to MTZ file
+        dataset_name : str
+            Dataset name to assign to MTZ file
         """
         from reciprocalspaceship import io
 
-        return io.write_mtz(self, mtzfile, skip_problem_mtztypes)
+        return io.write_mtz(
+            self,
+            mtzfile,
+            skip_problem_mtztypes,
+            project_name,
+            crystal_name,
+            dataset_name,
+        )
 
     def select_mtzdtype(self, dtype):
         """

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -1,6 +1,4 @@
 import gemmi
-import numpy as np
-import pandas as pd
 
 from reciprocalspaceship import DataSet
 from reciprocalspaceship.dtypes.base import MTZDtype
@@ -104,7 +102,7 @@ def to_gemmi(
         )
 
     # Build up a gemmi.Mtz object
-    mtz = gemmi.Mtz(with_base=True)  # Adds HKL_base
+    mtz = gemmi.Mtz()
     mtz.cell = dataset.cell
     mtz.spacegroup = dataset.spacegroup
 
@@ -117,25 +115,24 @@ def to_gemmi(
     # Add Dataset with indicated names
     mtz.add_dataset("reciprocalspaceship")
     if project_name:
-        mtz.datasets[1].project_name = project_name
+        mtz.datasets[0].project_name = project_name
     if crystal_name:
-        mtz.datasets[1].crystal_name = crystal_name
+        mtz.datasets[0].crystal_name = crystal_name
     if dataset_name:
-        mtz.datasets[1].dataset_name = dataset_name
+        mtz.datasets[0].dataset_name = dataset_name
 
     # Construct data for Mtz object
     temp = dataset.reset_index()
-    columns = ["H", "K", "L"]  # already in HKL_base
+    columns = []
     for c in temp.columns:
         cseries = temp[c]
         if isinstance(cseries.dtype, MTZDtype):
-            if c not in ["H", "K", "L"]:  # HKL already in HKL_base
-                mtz.add_column(label=c, type=cseries.dtype.mtztype)
-                columns.append(c)
+            mtz.add_column(label=c, type=cseries.dtype.mtztype)
+            columns.append(c)
         # Special case for CENTRIC and PARTIAL flags
         elif cseries.dtype.name == "bool" and c in ["CENTRIC", "PARTIAL"]:
             temp[c] = temp[c].astype("MTZInt")
-            mtz.add_column(label=c, type="I", dataset_id=1)
+            mtz.add_column(label=c, type="I")
             columns.append(c)
         elif skip_problem_mtztypes:
             continue

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -59,9 +59,9 @@ def from_gemmi(gemmi_mtz):
 def to_gemmi(
     dataset,
     skip_problem_mtztypes=False,
-    project_name=None,
-    crystal_name=None,
-    dataset_name=None,
+    project_name="reciprocalspaceship",
+    crystal_name="reciprocalspaceship",
+    dataset_name="reciprocalspaceship",
 ):
     """
     Construct gemmi.Mtz object from DataSet
@@ -181,9 +181,9 @@ def write_mtz(
     dataset,
     mtzfile,
     skip_problem_mtztypes=False,
-    project_name=None,
-    crystal_name=None,
-    dataset_name=None,
+    project_name="reciprocalspaceship",
+    crystal_name="reciprocalspaceship",
+    dataset_name="reciprocalspaceship",
 ):
     """
     Write an MTZ reflection file from the reflection data in a DataSet.

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -58,10 +58,10 @@ def from_gemmi(gemmi_mtz):
 
 def to_gemmi(
     dataset,
-    skip_problem_mtztypes=False,
-    project_name="reciprocalspaceship",
-    crystal_name="reciprocalspaceship",
-    dataset_name="reciprocalspaceship",
+    skip_problem_mtztypes,
+    project_name,
+    crystal_name,
+    dataset_name,
 ):
     """
     Construct gemmi.Mtz object from DataSet
@@ -191,10 +191,10 @@ def read_mtz(mtzfile):
 def write_mtz(
     dataset,
     mtzfile,
-    skip_problem_mtztypes=False,
-    project_name="reciprocalspaceship",
-    crystal_name="reciprocalspaceship",
-    dataset_name="reciprocalspaceship",
+    skip_problem_mtztypes,
+    project_name,
+    crystal_name,
+    dataset_name,
 ):
     """
     Write an MTZ reflection file from the reflection data in a DataSet.

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -101,6 +101,20 @@ def to_gemmi(
             f"Instance of type {dataset.__class__.__name__} has no space group information"
         )
 
+    # Check project_name, crystal_name, and dataset_name are str
+    if not isinstance(project_name, str):
+        raise ValueError(
+            f"project_name must be a string. Given type: {type(project_name)}"
+        )
+    if not isinstance(crystal_name, str):
+        raise ValueError(
+            f"crystal_name must be a string. Given type: {type(crystal_name)}"
+        )
+    if not isinstance(dataset_name, str):
+        raise ValueError(
+            f"dataset_name must be a string. Given type: {type(dataset_name)}"
+        )
+
     # Build up a gemmi.Mtz object
     mtz = gemmi.Mtz()
     mtz.cell = dataset.cell
@@ -114,12 +128,9 @@ def to_gemmi(
 
     # Add Dataset with indicated names
     mtz.add_dataset("reciprocalspaceship")
-    if project_name:
-        mtz.datasets[0].project_name = project_name
-    if crystal_name:
-        mtz.datasets[0].crystal_name = crystal_name
-    if dataset_name:
-        mtz.datasets[0].dataset_name = dataset_name
+    mtz.datasets[0].project_name = project_name
+    mtz.datasets[0].crystal_name = crystal_name
+    mtz.datasets[0].dataset_name = dataset_name
 
     # Construct data for Mtz object
     temp = dataset.reset_index()

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -173,19 +173,19 @@ def test_to_gemmi_names(IOtest_mtz, project_name, crystal_name, dataset_name):
         )
 
     if project_name:
-        assert gemmimtz.dataset(1).project_name == project_name
+        assert gemmimtz.dataset(0).project_name == project_name
     else:
-        assert gemmimtz.dataset(1).project_name == "reciprocalspaceship"
+        assert gemmimtz.dataset(0).project_name == "reciprocalspaceship"
 
     if crystal_name:
-        assert gemmimtz.dataset(1).crystal_name == crystal_name
+        assert gemmimtz.dataset(0).crystal_name == crystal_name
     else:
-        assert gemmimtz.dataset(1).crystal_name == "reciprocalspaceship"
+        assert gemmimtz.dataset(0).crystal_name == "reciprocalspaceship"
 
     if dataset_name:
-        assert gemmimtz.dataset(1).dataset_name == dataset_name
+        assert gemmimtz.dataset(0).dataset_name == dataset_name
     else:
-        assert gemmimtz.dataset(1).dataset_name == "reciprocalspaceship"
+        assert gemmimtz.dataset(0).dataset_name == "reciprocalspaceship"
 
 
 @pytest.mark.parametrize("project_name", [None, "project", 1])
@@ -221,18 +221,18 @@ def test_write_mtz_names(IOtest_mtz, project_name, crystal_name, dataset_name):
     gemmimtz = gemmi.read_mtz_file(temp.name)
 
     if project_name:
-        assert gemmimtz.dataset(1).project_name == project_name
+        assert gemmimtz.dataset(0).project_name == project_name
     else:
-        assert gemmimtz.dataset(1).project_name == "reciprocalspaceship"
+        assert gemmimtz.dataset(0).project_name == "reciprocalspaceship"
 
     if crystal_name:
-        assert gemmimtz.dataset(1).crystal_name == crystal_name
+        assert gemmimtz.dataset(0).crystal_name == crystal_name
     else:
-        assert gemmimtz.dataset(1).crystal_name == "reciprocalspaceship"
+        assert gemmimtz.dataset(0).crystal_name == "reciprocalspaceship"
 
     if dataset_name:
-        assert gemmimtz.dataset(1).dataset_name == dataset_name
+        assert gemmimtz.dataset(0).dataset_name == dataset_name
     else:
-        assert gemmimtz.dataset(1).dataset_name == "reciprocalspaceship"
+        assert gemmimtz.dataset(0).dataset_name == "reciprocalspaceship"
 
     temp.close()

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -3,7 +3,6 @@ import tempfile
 from os.path import exists
 
 import gemmi
-import numpy as np
 import pytest
 from pandas.testing import assert_frame_equal
 
@@ -145,3 +144,45 @@ def test_unmerged_after_write(data_unmerged, in_asu):
     expected = data_unmerged.copy()
     data_unmerged.write_mtz("/dev/null")
     assert_frame_equal(data_unmerged, expected)
+
+
+@pytest.mark.parametrize("project_name", [None, "project", 1])
+@pytest.mark.parametrize("crystal_name", [None, "crystal", 1])
+@pytest.mark.parametrize("dataset_name", [None, "dataset", 1])
+def test_to_gemmi_names(IOtest_mtz, project_name, crystal_name, dataset_name):
+    """
+    Test that DataSet.to_gemmi() sets project/crystal/dataset names when given.
+
+    Values should default to "reciprocalspaceship" when not given
+    """
+    ds = rs.read_mtz(IOtest_mtz)
+
+    if project_name == 1 or crystal_name == 1 or dataset_name == 1:
+        with pytest.raises(TypeError):
+            ds.to_gemmi(
+                project_name=project_name,
+                crystal_name=crystal_name,
+                dataset_name=dataset_name,
+            )
+        return
+    else:
+        gemmimtz = ds.to_gemmi(
+            project_name=project_name,
+            crystal_name=crystal_name,
+            dataset_name=dataset_name,
+        )
+
+    if project_name:
+        assert gemmimtz.dataset(1).project_name == project_name
+    else:
+        assert gemmimtz.dataset(1).project_name == "reciprocalspaceship"
+
+    if crystal_name:
+        assert gemmimtz.dataset(1).crystal_name == crystal_name
+    else:
+        assert gemmimtz.dataset(1).crystal_name == "reciprocalspaceship"
+
+    if dataset_name:
+        assert gemmimtz.dataset(1).dataset_name == dataset_name
+    else:
+        assert gemmimtz.dataset(1).dataset_name == "reciprocalspaceship"

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -146,62 +146,59 @@ def test_unmerged_after_write(data_unmerged, in_asu):
     assert_frame_equal(data_unmerged, expected)
 
 
-@pytest.mark.parametrize("project_name", [None, "project", 1])
-@pytest.mark.parametrize("crystal_name", [None, "crystal", 1])
-@pytest.mark.parametrize("dataset_name", [None, "dataset", 1])
+@pytest.mark.parametrize("project_name", [None, "project", "reciprocalspaceship", 1])
+@pytest.mark.parametrize("crystal_name", [None, "crystal", "reciprocalspaceship", 1])
+@pytest.mark.parametrize("dataset_name", [None, "dataset", "reciprocalspaceship", 1])
 def test_to_gemmi_names(IOtest_mtz, project_name, crystal_name, dataset_name):
     """
     Test that DataSet.to_gemmi() sets project/crystal/dataset names when given.
 
-    Values should default to "reciprocalspaceship" when not given
+    ValueError should be raised for anything other than a string.
     """
     ds = rs.read_mtz(IOtest_mtz)
 
-    if project_name == 1 or crystal_name == 1 or dataset_name == 1:
-        with pytest.raises(TypeError):
+    if (
+        not isinstance(project_name, str)
+        or not isinstance(crystal_name, str)
+        or not isinstance(dataset_name, str)
+    ):
+        with pytest.raises(ValueError):
             ds.to_gemmi(
                 project_name=project_name,
                 crystal_name=crystal_name,
                 dataset_name=dataset_name,
             )
         return
-    else:
-        gemmimtz = ds.to_gemmi(
-            project_name=project_name,
-            crystal_name=crystal_name,
-            dataset_name=dataset_name,
-        )
 
-    if project_name:
-        assert gemmimtz.dataset(0).project_name == project_name
-    else:
-        assert gemmimtz.dataset(0).project_name == "reciprocalspaceship"
+    gemmimtz = ds.to_gemmi(
+        project_name=project_name,
+        crystal_name=crystal_name,
+        dataset_name=dataset_name,
+    )
 
-    if crystal_name:
-        assert gemmimtz.dataset(0).crystal_name == crystal_name
-    else:
-        assert gemmimtz.dataset(0).crystal_name == "reciprocalspaceship"
-
-    if dataset_name:
-        assert gemmimtz.dataset(0).dataset_name == dataset_name
-    else:
-        assert gemmimtz.dataset(0).dataset_name == "reciprocalspaceship"
+    assert gemmimtz.dataset(0).project_name == project_name
+    assert gemmimtz.dataset(0).crystal_name == crystal_name
+    assert gemmimtz.dataset(0).dataset_name == dataset_name
 
 
-@pytest.mark.parametrize("project_name", [None, "project", 1])
-@pytest.mark.parametrize("crystal_name", [None, "crystal", 1])
-@pytest.mark.parametrize("dataset_name", [None, "dataset", 1])
+@pytest.mark.parametrize("project_name", [None, "project", "reciprocalspaceship", 1])
+@pytest.mark.parametrize("crystal_name", [None, "crystal", "reciprocalspaceship", 1])
+@pytest.mark.parametrize("dataset_name", [None, "dataset", "reciprocalspaceship", 1])
 def test_write_mtz_names(IOtest_mtz, project_name, crystal_name, dataset_name):
     """
     Test that DataSet.write_mtz() sets project/crystal/dataset names when given.
 
-    Values should default to "reciprocalspaceship" when not given
+    ValueError should be raised for anything other than a string.
     """
     ds = rs.read_mtz(IOtest_mtz)
 
     temp = tempfile.NamedTemporaryFile(suffix=".mtz")
-    if project_name == 1 or crystal_name == 1 or dataset_name == 1:
-        with pytest.raises(TypeError):
+    if (
+        not isinstance(project_name, str)
+        or not isinstance(crystal_name, str)
+        or not isinstance(dataset_name, str)
+    ):
+        with pytest.raises(ValueError):
             ds.write_mtz(
                 temp.name,
                 project_name=project_name,
@@ -220,19 +217,9 @@ def test_write_mtz_names(IOtest_mtz, project_name, crystal_name, dataset_name):
 
     gemmimtz = gemmi.read_mtz_file(temp.name)
 
-    if project_name:
-        assert gemmimtz.dataset(0).project_name == project_name
-    else:
-        assert gemmimtz.dataset(0).project_name == "reciprocalspaceship"
+    assert gemmimtz.dataset(0).project_name == project_name
+    assert gemmimtz.dataset(0).crystal_name == crystal_name
+    assert gemmimtz.dataset(0).dataset_name == dataset_name
 
-    if crystal_name:
-        assert gemmimtz.dataset(0).crystal_name == crystal_name
-    else:
-        assert gemmimtz.dataset(0).crystal_name == "reciprocalspaceship"
-
-    if dataset_name:
-        assert gemmimtz.dataset(0).dataset_name == dataset_name
-    else:
-        assert gemmimtz.dataset(0).dataset_name == "reciprocalspaceship"
-
+    # Clean up
     temp.close()

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -186,3 +186,53 @@ def test_to_gemmi_names(IOtest_mtz, project_name, crystal_name, dataset_name):
         assert gemmimtz.dataset(1).dataset_name == dataset_name
     else:
         assert gemmimtz.dataset(1).dataset_name == "reciprocalspaceship"
+
+
+@pytest.mark.parametrize("project_name", [None, "project", 1])
+@pytest.mark.parametrize("crystal_name", [None, "crystal", 1])
+@pytest.mark.parametrize("dataset_name", [None, "dataset", 1])
+def test_write_mtz_names(IOtest_mtz, project_name, crystal_name, dataset_name):
+    """
+    Test that DataSet.write_mtz() sets project/crystal/dataset names when given.
+
+    Values should default to "reciprocalspaceship" when not given
+    """
+    ds = rs.read_mtz(IOtest_mtz)
+
+    temp = tempfile.NamedTemporaryFile(suffix=".mtz")
+    if project_name == 1 or crystal_name == 1 or dataset_name == 1:
+        with pytest.raises(TypeError):
+            ds.write_mtz(
+                temp.name,
+                project_name=project_name,
+                crystal_name=crystal_name,
+                dataset_name=dataset_name,
+            )
+        temp.close()
+        return
+    else:
+        ds.write_mtz(
+            temp.name,
+            project_name=project_name,
+            crystal_name=crystal_name,
+            dataset_name=dataset_name,
+        )
+
+    gemmimtz = gemmi.read_mtz_file(temp.name)
+
+    if project_name:
+        assert gemmimtz.dataset(1).project_name == project_name
+    else:
+        assert gemmimtz.dataset(1).project_name == "reciprocalspaceship"
+
+    if crystal_name:
+        assert gemmimtz.dataset(1).crystal_name == crystal_name
+    else:
+        assert gemmimtz.dataset(1).crystal_name == "reciprocalspaceship"
+
+    if dataset_name:
+        assert gemmimtz.dataset(1).dataset_name == dataset_name
+    else:
+        assert gemmimtz.dataset(1).dataset_name == "reciprocalspaceship"
+
+    temp.close()


### PR DESCRIPTION
This PR addresses #103 by adding an interface for setting the project, crystal, and dataset names in `DataSet.to_gemmi()` and `DataSet.write_mtz()`. These names are then set in the MTZ file or `gemmi.Mtz` object.

This can be useful for record keeping, allowing custom titles in MTZ files that can be read by other programs. 

These names default to "reciprocalspaceship" -- if these new arguments are left unset, a user will have the same behavior as before.