### PR TITLE
Add features to the add_rfree function

### DIFF
--- a/reciprocalspaceship/utils/rfree.py
+++ b/reciprocalspaceship/utils/rfree.py
@@ -3,7 +3,7 @@ import numpy as np
 from reciprocalspaceship.dtypes import MTZIntDtype
 
 
-def add_rfree(dataset, fraction=0.05, bins=20, inplace=False):
+def add_rfree(dataset, fraction=0.05, bins=20, ccp4_convention=False, inplace=False):
     """
     Add an r-free flag to the dataset object for refinement.
     R-free flags are used to identify reflections which are not used in automated refinement routines.
@@ -17,6 +17,10 @@ def add_rfree(dataset, fraction=0.05, bins=20, inplace=False):
         Fraction of reflections to be added to the r-free. (the default is 0.05)
     bins : int, optional
         Number of resolution bins to divide the free reflections over. (the default is 20)
+    ccp4_conventiion: bool, optional
+        Default False to use Phenix(CNS/XPLOR) convention: !=0 is test set and key is "R-free-flags".
+        Set to True to use ccp4 convention: ==0 is test set and the key is "FreeR_flag".
+        See https://www.ccp4.ac.uk/html/freerflag.html#description for convention details.
     inplace : bool, optional
 
     Returns
@@ -33,14 +37,21 @@ def add_rfree(dataset, fraction=0.05, bins=20, inplace=False):
     bin_edges = np.percentile(dataset["dHKL"], np.linspace(100, 0, bins + 1))
     bin_edges = np.vstack([bin_edges[:-1], bin_edges[1:]]).T
 
-    dataset["R-free-flags"] = 0
-    dataset["R-free-flags"] = dataset["R-free-flags"].astype(MTZIntDtype())
+    test_set = np.random.random(len(dataset)) <= fraction
 
-    free = np.random.random(len(dataset)) <= fraction
+    if not ccp4_convention:
+        rfree_key = "R-free-flags"
+        update = test_set
+    else:
+        rfree_key = "FreeR_flags"
+        update = ~test_set
+
+    dataset[rfree_key] = 0
+    dataset[rfree_key] = dataset[rfree_key].astype(MTZIntDtype())
 
     for i in range(bins):
         dmax, dmin = bin_edges[i]
-        dataset[free & (dataset["dHKL"] >= dmin) & (dataset["dHKL"] <= dmax)] = i
+        dataset[update & (dataset["dHKL"] >= dmin) & (dataset["dHKL"] <= dmax)][rfree_key] = i+1
 
     if not dHKL_present:
         del dataset["dHKL"]

--- a/reciprocalspaceship/utils/rfree.py
+++ b/reciprocalspaceship/utils/rfree.py
@@ -51,7 +51,7 @@ def add_rfree(dataset, fraction=0.05, bins=20, ccp4_convention=False, inplace=Fa
 
     for i in range(bins):
         dmax, dmin = bin_edges[i]
-        dataset[update & (dataset["dHKL"] >= dmin) & (dataset["dHKL"] <= dmax)][rfree_key] = i+1
+        dataset.loc[update & (dataset["dHKL"] >= dmin) & (dataset["dHKL"] <= dmax), rfree_key] = i+1
 
     if not dHKL_present:
         del dataset["dHKL"]

--- a/reciprocalspaceship/utils/rfree.py
+++ b/reciprocalspaceship/utils/rfree.py
@@ -16,9 +16,9 @@ def add_rfree(dataset, fraction=0.05, ccp4_convention=False, inplace=False):
     fraction : float, optional
         Fraction of reflections to be added to the r-free. (the default is 0.05)
     ccp4_conventiion: bool, optional
-        Default False to use Phenix(CNS/XPLOR) convention: 
+        Default False to use Phenix(CNS/XPLOR) convention:
         1 is test set, 0 is working set, and key is "R-free-flags".
-        Set to True to use ccp4 convention: 
+        Set to True to use ccp4 convention:
         0 is test set, 1 is working set, and the key is "FreeR_flag".
         See https://www.ccp4.ac.uk/html/freerflag.html#description for convention details.
     inplace : bool, optional

--- a/reciprocalspaceship/utils/rfree.py
+++ b/reciprocalspaceship/utils/rfree.py
@@ -16,10 +16,11 @@ def add_rfree(dataset, fraction=0.05, ccp4_convention=False, inplace=False):
     fraction : float, optional
         Fraction of reflections to be added to the r-free. (the default is 0.05)
     ccp4_conventiion: bool, optional
-        Default False to use Phenix(CNS/XPLOR) convention:
-        1 is test set, 0 is working set, and key is "R-free-flags".
-        Set to True to use ccp4 convention:
+        Whether to use the CCP4 convention for R-free flags (Default: False). 
+        If True, use CCP4 convention:
         0 is test set, 1 is working set, and the key is "FreeR_flag".
+        If False, use Phenix(CNS/XPOLAR) convention:
+        1 is test set, 0 is working set, and key is "R-free-flags".
         See https://www.ccp4.ac.uk/html/freerflag.html#description for convention details.
     inplace : bool, optional
 

--- a/reciprocalspaceship/utils/rfree.py
+++ b/reciprocalspaceship/utils/rfree.py
@@ -43,7 +43,7 @@ def add_rfree(dataset, fraction=0.05, bins=20, ccp4_convention=False, inplace=Fa
         rfree_key = "R-free-flags"
         update = test_set
     else:
-        rfree_key = "FreeR_flags"
+        rfree_key = "FreeR_flag"
         update = ~test_set
 
     dataset[rfree_key] = 0

--- a/reciprocalspaceship/utils/rfree.py
+++ b/reciprocalspaceship/utils/rfree.py
@@ -16,7 +16,7 @@ def add_rfree(dataset, fraction=0.05, ccp4_convention=False, inplace=False):
     fraction : float, optional
         Fraction of reflections to be added to the r-free. (the default is 0.05)
     ccp4_conventiion: bool, optional
-        Whether to use the CCP4 convention for R-free flags (Default: False). 
+        Whether to use the CCP4 convention for R-free flags (Default: False).
         If True, use CCP4 convention:
         0 is test set, 1 is working set, and the key is "FreeR_flag".
         If False, use Phenix(CNS/XPOLAR) convention:

--- a/tests/utils/test_rfree.py
+++ b/tests/utils/test_rfree.py
@@ -21,7 +21,7 @@ class TestRfree(unittest.TestCase):
         # Should keep all other unchanged
         self.assertTrue(np.all(data == rfree.loc[:, rfree.columns != "R-free-flags"]))
         # Should have fewer ==1 as test set
-        self.assertTrue(np.sum(rfree.loc[:, "R-free-flags"] == 1)/len(rfree) < 0.15)
+        self.assertTrue(np.sum(rfree.loc[:, "R-free-flags"] == 1) / len(rfree) < 0.15)
 
         # Test ccp4_convention
         rfree_ccp4 = rs.utils.add_rfree(data, ccp4_convention=True)

--- a/tests/utils/test_rfree.py
+++ b/tests/utils/test_rfree.py
@@ -20,8 +20,8 @@ class TestRfree(unittest.TestCase):
 
         # Should keep all other unchanged
         self.assertTrue(np.all(data == rfree.loc[:, rfree.columns != "R-free-flags"]))
-        # Should have fewer !=0 as test set
-        self.assertTrue(np.sum(rfree.loc[:, "R-free-flags"] != 0)/len(rfree) < 0.15)
+        # Should have fewer ==1 as test set
+        self.assertTrue(np.sum(rfree.loc[:, "R-free-flags"] == 1)/len(rfree) < 0.15)
 
         # Test ccp4_convention
         rfree_ccp4 = rs.utils.add_rfree(data, ccp4_convention=True)

--- a/tests/utils/test_rfree.py
+++ b/tests/utils/test_rfree.py
@@ -2,48 +2,40 @@ import unittest
 from os.path import abspath, dirname, join
 
 import numpy as np
+import pytest
 
 import reciprocalspaceship as rs
 
+@pytest.mark.parametrize("fraction", [0.05, 0.10, 0.15])
+@pytest.mark.parametrize("ccp4_convention", [False, True])
+@pytest.mark.parametrize("inplace", [False, True])
+def test_add_rfree(data_fmodel, fraction, ccp4_convention, inplace):
+    '''
+    Test rs.utils.add_rfee
+    '''
+    data_copy = data_fmodel.copy()
+    rfree = rs.utils.add_rfree(data_fmodel, fraction=fraction, ccp4_convention=ccp4_convention, inplace=inplace)
+
+    if ccp4_convention:
+        label_name = "FreeR_flag"
+        assert label_name in rfree.columns
+        assert np.sum(rfree.loc[:, label_name] == 0) / len(rfree) < fraction+0.1
+    else:
+        label_name = "R-free-flags"
+        assert label_name in rfree.columns
+        assert np.sum(rfree.loc[:, label_name] == 1) / len(rfree) < fraction+0.1
+
+    if inplace:
+        assert id(data_fmodel) == id(rfree)
+        assert label_name in data_fmodel.columns
+        assert np.all(data_copy == rfree.loc[:, rfree.columns != label_name]) 
+    else:
+        assert id(data_fmodel) != id(rfree)
+        assert label_name not in data_fmodel.columns
+        assert np.all(data_fmodel == data_copy)
+        assert np.all(data_fmodel == rfree.loc[:, rfree.columns != label_name])
 
 class TestRfree(unittest.TestCase):
-    def test_add_rfree(self):
-
-        datadir = join(abspath(dirname(__file__)), "../data/fmodel")
-        data = rs.read_mtz(join(datadir, "9LYZ.mtz"))
-
-        # Should copy data
-        rfree = rs.utils.add_rfree(data)
-        self.assertFalse(id(data) == id(rfree))
-        self.assertFalse("R-free-flags" in data.columns)
-        self.assertTrue("R-free-flags" in rfree.columns)
-
-        # Should keep all other unchanged
-        self.assertTrue(np.all(data == rfree.loc[:, rfree.columns != "R-free-flags"]))
-        # Should have fewer ==1 as test set
-        self.assertTrue(np.sum(rfree.loc[:, "R-free-flags"] == 1) / len(rfree) < 0.15)
-
-        # Test ccp4_convention
-        rfree_ccp4 = rs.utils.add_rfree(data, ccp4_convention=True)
-        self.assertTrue("FreeR_flag" in rfree_ccp4.columns)
-
-        # Should keep all other unchanged
-        self.assertTrue(
-            np.all(data == rfree_ccp4.loc[:, rfree_ccp4.columns != "FreeR_flag"])
-        )
-        # Should have fewer ==0 as test set
-        self.assertTrue(
-            np.sum(rfree_ccp4.loc[:, "FreeR_flag"] == 0) / len(rfree_ccp4) < 0.15
-        )
-
-        # Test inplace option
-        rfree = rs.utils.add_rfree(data, inplace=True)
-        self.assertTrue(id(data) == id(rfree))
-        self.assertTrue("R-free-flags" in data.columns)
-        self.assertTrue("R-free-flags" in rfree.columns)
-
-        return
-
     def test_copy_rfree(self):
 
         datadir = join(abspath(dirname(__file__)), "../data/fmodel")

--- a/tests/utils/test_rfree.py
+++ b/tests/utils/test_rfree.py
@@ -6,34 +6,38 @@ import pytest
 
 import reciprocalspaceship as rs
 
+
 @pytest.mark.parametrize("fraction", [0.05, 0.10, 0.15])
 @pytest.mark.parametrize("ccp4_convention", [False, True])
 @pytest.mark.parametrize("inplace", [False, True])
 def test_add_rfree(data_fmodel, fraction, ccp4_convention, inplace):
-    '''
+    """
     Test rs.utils.add_rfee
-    '''
+    """
     data_copy = data_fmodel.copy()
-    rfree = rs.utils.add_rfree(data_fmodel, fraction=fraction, ccp4_convention=ccp4_convention, inplace=inplace)
+    rfree = rs.utils.add_rfree(
+        data_fmodel, fraction=fraction, ccp4_convention=ccp4_convention, inplace=inplace
+    )
 
     if ccp4_convention:
         label_name = "FreeR_flag"
         assert label_name in rfree.columns
-        assert np.sum(rfree.loc[:, label_name] == 0) / len(rfree) < fraction+0.1
+        assert np.sum(rfree.loc[:, label_name] == 0) / len(rfree) < fraction + 0.1
     else:
         label_name = "R-free-flags"
         assert label_name in rfree.columns
-        assert np.sum(rfree.loc[:, label_name] == 1) / len(rfree) < fraction+0.1
+        assert np.sum(rfree.loc[:, label_name] == 1) / len(rfree) < fraction + 0.1
 
     if inplace:
         assert id(data_fmodel) == id(rfree)
         assert label_name in data_fmodel.columns
-        assert np.all(data_copy == rfree.loc[:, rfree.columns != label_name]) 
+        assert np.all(data_copy == rfree.loc[:, rfree.columns != label_name])
     else:
         assert id(data_fmodel) != id(rfree)
         assert label_name not in data_fmodel.columns
         assert np.all(data_fmodel == data_copy)
         assert np.all(data_fmodel == rfree.loc[:, rfree.columns != label_name])
+
 
 class TestRfree(unittest.TestCase):
     def test_copy_rfree(self):

--- a/tests/utils/test_rfree.py
+++ b/tests/utils/test_rfree.py
@@ -18,6 +18,20 @@ class TestRfree(unittest.TestCase):
         self.assertFalse("R-free-flags" in data.columns)
         self.assertTrue("R-free-flags" in rfree.columns)
 
+        # Should keep all other unchanged
+        self.assertTrue(np.all(data == rfree.loc[:, rfree.columns != "R-free-flags"]))
+        # Should have fewer !=0 as test set
+        self.assertTrue(np.sum(rfree.loc[:, "R-free-flags"] != 0)/len(rfree) < 0.15)
+
+        # Test ccp4_convention
+        rfree_ccp4 = rs.utils.add_rfree(data, ccp4_convention=True)
+        self.assertTrue("FreeR_flag" in rfree_ccp4.columns)
+
+        # Should keep all other unchanged
+        self.assertTrue(np.all(data == rfree_ccp4.loc[:, rfree_ccp4.columns != "FreeR_flag"]))
+        # Should have fewer ==0 as test set
+        self.assertTrue(np.sum(rfree_ccp4.loc[:, "FreeR_flag"] == 0)/len(rfree_ccp4) < 0.15)
+
         # Test inplace option
         rfree = rs.utils.add_rfree(data, inplace=True)
         self.assertTrue(id(data) == id(rfree))


### PR DESCRIPTION
1. Support ccp4 convention now: 0 is the test set and key is FreeR_flag
2. Update related test codes
3. Fix the previous bugs about updating more than the free flag column. Add some test codes to prevent such issues in the future. 