### PR TITLE
Model-free alignment of isomorphous maps (alternative origins problem)

### DIFF
--- a/reciprocalspaceship/algorithms/translator.py
+++ b/reciprocalspaceship/algorithms/translator.py
@@ -1,0 +1,149 @@
+import numpy as np
+
+
+class BaseTranslator:
+    def __init__(self, H, phi_ref, phi, dhkl):
+        """
+        Translator class for determining the optimal translation
+        vector to align two sets of phases.
+
+        Parameters
+        ----------
+        H : np.ndarray
+            Miller indices as an N x 3 array
+        phi_ref : np.ndarray
+            Reference phases in degrees (length N)
+        phi : np.ndarray
+            Other phases to align to reference in degrees (length N)
+        dhkl : np.ndarray
+            Interplane spacing of each Miller index (length N)
+
+        Raises
+        ------
+        ValueError
+            Raises ValueError if dimensions of arrays do not correspond
+        """
+        if H.shape[1] != 3:
+            raise ValueError(f"Miller index array must be N x 3, given: {H.shape}")
+
+        nrefls = H.shape[0]
+        if len(phi_ref) != nrefls or len(phi) != nrefls or len(dhkl) != nrefls:
+            raise ValueError(
+                "All arrays must correspond to the same number of reflections."
+            )
+
+        # Provide inputs as attributes
+        self.H = H
+        self.phi_ref = phi_ref
+        self.phi = phi
+        self.dhkl = dhkl
+
+        # Helper attributes
+        self.translation = np.array([0.0, 0.0, 0.0])
+        self.D = (np.deg2rad(phi) - np.deg2rad(phi_ref)) / (2.0 * np.pi)
+        self.mask = self.dhkl > 0.0
+        self.a_bounds = (0.0, 1.0)
+        self.b_bounds = (0.0, 1.0)
+        self.c_bounds = (0.0, 1.0)
+
+    def set_mask(self, dmin):
+        """
+        Set mask to restrict the set of reflections to those with dhkl > dmin.
+
+        Parameters
+        ----------
+        dmin : float
+            Minimal dhkl to consider
+        """
+        self.mask = self.dhkl > dmin
+        return
+
+    def _phase_residual(self, t):
+        """Phase residual in cycles"""
+        if t.ndim == 1:
+            residual = self.D[self.mask] - self.H[self.mask] @ t
+        else:
+            residual = self.D[self.mask][:, None] - self.H[self.mask] @ t.T
+        return residual - np.round(residual)
+
+    def evaluate(self, t):
+        """
+        Evaluate loss function using sum of the squared phase residuals (in cycles).
+
+        Parameters
+        ----------
+        t : np.ndarray(3) or np.ndarray(N, 3)
+            Translation vector(s) to evaluate
+
+        Returns
+        -------
+        loss : float
+        """
+        return np.sum(np.square(self._phase_residual(t)), axis=0)
+
+    def phase_rmsd(self):
+        """
+        Compute phase RMSD for current translation vector in degrees
+
+        Returns
+        -------
+        rmsd : float
+        """
+        residual = self._phase_residual(self.translation) * 2 * np.pi
+        rmsd = np.sqrt(np.mean(residual * residual))
+        return np.rad2deg(rmsd)
+
+
+class PolarTranslator(BaseTranslator):
+    def fit(self, dmin=0.0):
+        """
+        Determine the best translation vector by global optimization.
+
+        Parameters
+        ----------
+        dmin : float
+            Minimal dhkl to consider (default: 0.0; all reflections)
+
+        Returns
+        -------
+        translation : np.ndarray
+        """
+        from scipy.optimize import dual_annealing
+
+        self.set_mask(dmin=dmin)
+
+        result = dual_annealing(
+            self.evaluate,
+            x0=self.translation,
+            bounds=(self.a_bounds, self.b_bounds, self.c_bounds),
+            minimizer_kwargs={"tol": 1e-10},
+        )
+        if result.success:
+            self.translation = result.x
+            return self.translation
+        else:
+            raise RuntimeError("Global optimization failed")
+
+
+class NonPolarTranslator(BaseTranslator):
+    def fit(self, dmin=0.0):
+        """
+        Determine the best translation vector by brute force search.
+
+        Parameters
+        ----------
+        dmin : float
+            Minimal dhkl to consider (default: 0.0; all reflections)
+
+        Returns
+        -------
+        translation : np.ndarray
+        """
+        self.set_mask(dmin=dmin)
+
+        cases = np.array([0.0, 1.0 / 3.0, 0.5, 2.0 / 3.0])
+        t_cases = np.vstack(np.meshgrid(cases, cases, cases)).reshape((3, -1)).T
+        loss = self.evaluate(t_cases)
+        self.translation = t_cases[np.argmin(loss)]
+
+        return self.translation

--- a/tests/algorithms/test_translator.py
+++ b/tests/algorithms/test_translator.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytest
+
+from reciprocalspaceship.algorithms import translator
+
+
+@pytest.mark.parametrize(
+    "translator_class", [translator.PolarTranslator, translator.NonPolarTranslator]
+)
+def test_initialization(hkls, translator_class):
+    """
+    Test initialization of PolarTranslator and NonPolarTranslator
+    """
+    phi_ref = np.linspace(0, 360, len(hkls))
+    phi = np.linspace(0, 360, len(hkls))
+    dhkl = np.linspace(1, 100, len(hkls))
+
+    # Malformed Miller index array should raise ValueError
+    with pytest.raises(ValueError):
+        solver = translator_class(hkls[:, :2], phi_ref, phi, dhkl)
+
+    # Mismatched array lengths should cause ValueErrors
+    with pytest.raises(ValueError):
+        solver = translator_class(hkls[:-1], phi_ref, phi, dhkl)
+    with pytest.raises(ValueError):
+        solver = translator_class(hkls, phi_ref[:-1], phi, dhkl)
+    with pytest.raises(ValueError):
+        solver = translator_class(hkls, phi_ref, phi[:-1], dhkl)
+    with pytest.raises(ValueError):
+        solver = translator_class(hkls, phi_ref, phi, dhkl[:-1])
+
+    solver = translator_class(hkls, phi_ref, phi, dhkl)
+
+    # Since phi_ref == phi, rmsd should be 0.0
+    assert solver.phase_rmsd() == 0.0
+
+    # Loss function with initial translation vector should be 0.0
+    assert np.array_equal(solver.translation, np.array([0.0, 0.0, 0.0]))
+    assert solver.evaluate(solver.translation) == 0.0
+
+    # fit() methods should return [0.0, 0.0, 0.0] -- no translation needed
+    assert np.array_equal(solver.fit(), np.array([0.0, 0.0, 0.0]))
+
+
+@pytest.mark.parametrize(
+    "translator_class", [translator.PolarTranslator, translator.NonPolarTranslator]
+)
+@pytest.mark.parametrize(
+    "translation",
+    [np.array([0.0, 0.0, 0.0]), np.array([1.0, 1.0, 1.0]), np.array([2.0, 2.0, 2.0])],
+)
+def test_evaluate_integers(hkls, translator_class, translation):
+    """
+    Test evaluate() returns 0.0 with integer fractional cell lengths
+    """
+    phi_ref = np.linspace(0, 360, len(hkls))
+    phi = np.linspace(0, 360, len(hkls))
+    dhkl = np.linspace(1, 100, len(hkls))
+
+    solver = translator_class(hkls, phi_ref, phi, dhkl)
+    assert solver.evaluate(translation) == 0.0
+
+
+@pytest.mark.parametrize(
+    "translator_class", [translator.PolarTranslator, translator.NonPolarTranslator]
+)
+@pytest.mark.parametrize(
+    "translation",
+    [
+        np.array([0.5, 0.0, 0.0]),
+        np.array([0.0, 0.5, 0.0]),
+        np.array([0.0, 0.0, 0.5]),
+        np.array([0.25, 0.25, 0.25]),
+        np.array([0.1, 0.2, 0.3]),
+    ],
+)
+def test_evaluate_fractional(hkls, translator_class, translation):
+    """
+    Test evaluate() returns > 0.0 with fractional cell lengths
+    """
+    phi_ref = np.linspace(0, 360, len(hkls))
+    phi = np.linspace(0, 360, len(hkls))
+    dhkl = np.linspace(1, 100, len(hkls))
+
+    solver = translator_class(hkls, phi_ref, phi, dhkl)
+    assert solver.evaluate(translation) > 0.0


### PR DESCRIPTION
This PR is still in progress, but I wanted to upload my initial classes to support this. The problem is broken down into two cases:
1. Non-Polar spacegroups: easier case because they have a finite number of cases to evaluate
2. Polar spacegroups: more challenging because of the continuous alternative origins. 

These classes use the sum of the squared phase residual between two sets of phases as a loss function to minimize, which has been pretty effective in my hands. 

The `NonPolarTranslator` does a brute-force search of the 64 possible cases to evaluate the optimal translation vector. The `PolarTranslator` does a global optimization to determine the optimal translation vector. This is a bit non-trivial -- its a bumpy loss landscape -- but I've found the scipy dual_annealing optimizer to work very well. Another trick has been to start at low-resolution and gradually increase to full resolution. After discussion with @kmdalton, we can also use a FFT-based method to come up with a sensible initial value for optimization. 

My todo items:
- [ ] Add user-facing method that takes two datasets, and uses the proper class based on the spacegroup to determine the translation vector that gives a common phase origin.
- [ ] Add a suite of tests for common spacegroups that cover the polar/non-polar cases
- [ ] (optional improvement) Add initialization code based on FFT-method to speed things up