### PR TITLE
Add `is_polar()` and `polar_axes()` to utility functions docs

### DIFF
--- a/reciprocalspaceship/utils/__init__.py
+++ b/reciprocalspaceship/utils/__init__.py
@@ -8,6 +8,8 @@ __all__ = [
     "is_centric",
     "is_absent",
     "apply_to_hkl",
+    "is_polar",
+    "polar_axes",
     "phase_shift",
     "add_rfree",
     "copy_rfree",


### PR DESCRIPTION
I forgot to add `rs.utils.is_polar()` and `rs.utils.polar_axes()` to `rs.utils.__all__`, which means that the functions were left off the "Developers" section of the documentation. This PR adds those functions to `rs.utils.__all__` so that the functions are added to the utility functions documentation (https://hekstra-lab.github.io/reciprocalspaceship/developers/utilities.html)