### PR TITLE
`DataSet.to_numpy()` should use numpy dtypes whenever possible

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1,5 +1,3 @@
-from inspect import signature
-
 import gemmi
 import numpy as np
 import pandas as pd

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -325,8 +325,7 @@ class DataSet(pd.DataFrame):
             dtype_list = [self.dtypes[k] for k in self]
 
             # If all dtypes are MTZInt32Dtype, we can coerce to either int32 or float32
-            all_mtzints = all([isinstance(d, MTZInt32Dtype) for d in dtype_list])
-            if all_mtzints:
+            if all([isinstance(d, MTZInt32Dtype) for d in dtype_list]):
                 if not any([self[k].hasnans for k in self]):
                     return super().to_numpy(dtype="int32", copy=copy, na_value=na_value)
                 else:
@@ -335,8 +334,7 @@ class DataSet(pd.DataFrame):
                     )
 
             # All MTZDtypes can be represented as float32
-            all_mtzdtypes = all([isinstance(d, MTZDtype) for d in dtype_list])
-            if all_mtzdtypes:
+            if all([isinstance(d, MTZDtype) for d in dtype_list]):
                 return super().to_numpy(dtype="float32", copy=copy, na_value=na_value)
 
         # Use Pandas default behavior

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -297,12 +297,14 @@ class DataSet(pd.DataFrame):
         """
         Convert the DataSet to a NumPy array.
 
-        By default, the returned array will be `float32` if all columns of the DataSet are
-        MTZ dtypes. If the DataSet is composed of only `int32`-backed MTZ dtypes and does
-        not contain any NaN values, an `int32` array by `int32` and does not contain NaN
-        values, this will be `int32`. If the DataSet contains only MTZ dtypes (but not all
-        `int32`-backed or contains NaNs) the returned array will be `float32`. Otherwise,
-        the default Pandas behavior will be used.
+        This method will attempt to infer a consensus numpy dtype from the dtypes
+        of the DataSet columns. If the DataSet is composed of all `int32`-backed
+        MTZ dtypes and does contain NaN values, the returned `dtype` will be `int32`.
+        For all other combinations of `MTZDtype`, the returned dtype will be `float32`.
+        If the DataSet contains dtypes other than `MTZDtype`, the default Pandas
+        behavior is used (see `Pandas documentation`_).
+
+        .. _Pandas documentation: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_numpy.html
 
         Parameters
         ----------

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -299,15 +299,15 @@ class DataSet(pd.DataFrame):
 
         By default, the returned array will be `float32` if all columns of the DataSet are
         MTZ dtypes. If the DataSet is composed of only `int32`-backed MTZ dtypes and does
-        not contain any NaN values, an `int32` array
-        by `int32` and does not contain NaN values, this will be `int32`. If the DataSet
-        contains only MTZ dtypes (but not all int32-backed or contains NaNs) the returned
-        array will be `float32`. Otherwise, the default Pandas behavior will be used.
+        not contain any NaN values, an `int32` array by `int32` and does not contain NaN
+        values, this will be `int32`. If the DataSet contains only MTZ dtypes (but not all
+        `int32`-backed or contains NaNs) the returned array will be `float32`. Otherwise,
+        the default Pandas behavior will be used.
 
         Parameters
         ----------
         dtype : str or np.dtype
-            The dtype to pass to `np.asarray()` (optional)
+            The dtype to pass to `np.asarray()`
         copy : bool
             Whether to ensure that the returned value is not a view on another array.
             Note that `copy=False` does not ensure that `to_numpy()` is no-copy. Rather,

--- a/tests/dtypes/test_dataset_to_numpy.py
+++ b/tests/dtypes/test_dataset_to_numpy.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import reciprocalspaceship as rs
+
+
+@pytest.mark.parametrize("dtype", [None, np.int32, np.float32, np.float64, object])
+@pytest.mark.parametrize("hasna", [True, False])
+def test_to_numpy_ints(dtype, hasna):
+    """
+    Test DataSet.to_numpy() with int32-backed MTZDtypes
+    """
+    ds = rs.DataSet(
+        {
+            "X": np.random.randint(0, 100, size=100),
+            "Y": np.random.randint(0, 100, size=100),
+        }
+    ).infer_mtz_dtypes()
+
+    if hasna:
+        ds.loc[0, "X"] = np.nan
+
+    # Can't represent array with np.int32
+    if hasna and dtype is np.int32:
+        with pytest.raises(ValueError):
+            arr = ds.to_numpy(dtype=dtype)
+    else:
+        arr = ds.to_numpy(dtype=dtype)
+
+        if dtype is None:
+            # Fall back to float32
+            if hasna:
+                assert arr.dtype == np.float32
+            # Fall back to int32
+            else:
+                assert arr.dtype == np.int32
+        else:
+            assert arr.dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", [None, np.float32, np.float64, object])
+@pytest.mark.parametrize("hasna", [True, False])
+def test_to_numpy_floats(dtype, hasna):
+    """
+    Test DataSet.to_numpy() with float32-backed MTZDtypes
+    """
+    ds = rs.DataSet(
+        {
+            "X": np.random.random(100),
+            "Y": np.random.random(100),
+        }
+    ).infer_mtz_dtypes()
+
+    if hasna:
+        ds.loc[0, "X"] = np.nan
+
+    arr = ds.to_numpy(dtype=dtype)
+
+    if dtype is None:
+        # Fall back to float32
+        assert arr.dtype == np.float32
+    else:
+        assert arr.dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", [None, np.float32, np.float64, object])
+@pytest.mark.parametrize("hasna", [True, False])
+def test_to_numpy_mtzdtypes(dtype, hasna):
+    """
+    Test DataSet.to_numpy() with both int32-backed and float-32-backed MTZDtypes
+    """
+    ds = rs.DataSet(
+        {
+            "X": np.random.random(100),
+            "Y": np.random.randint(100),
+        }
+    ).infer_mtz_dtypes()
+
+    if hasna:
+        ds.loc[0, "X"] = np.nan
+
+    arr = ds.to_numpy(dtype=dtype)
+
+    if dtype is None:
+        # Fall back to float32
+        assert arr.dtype == np.float32
+    else:
+        assert arr.dtype == dtype
+
+
+@pytest.mark.parametrize("non_mtzdtype", ["string", np.int32, np.float32, bool, object])
+def test_to_numpy_object(non_mtzdtype):
+    """
+    With a non-MTZDtype, DataSet.to_numpy() should always output the same thing as
+    an pandas.DataFrame.to_numpy(). Currently, that is "object".
+    """
+    ds = rs.DataSet(
+        {
+            "X": np.random.random(100),
+            "Y": np.random.randint(100),
+        }
+    ).infer_mtz_dtypes()
+    ds["non_mtz"] = 0
+    ds["non_mtz"] = ds["non_mtz"].astype(non_mtzdtype)
+
+    result = ds.to_numpy()
+    expected = pd.DataFrame(ds).to_numpy()
+
+    assert result.dtype == expected.dtype

--- a/tests/dtypes/test_dataset_to_numpy.py
+++ b/tests/dtypes/test_dataset_to_numpy.py
@@ -7,16 +7,17 @@ import reciprocalspaceship as rs
 
 @pytest.mark.parametrize("dtype", [None, np.int32, np.float32, np.float64, object])
 @pytest.mark.parametrize("hasna", [True, False])
-def test_to_numpy_ints(dtype, hasna):
+def test_to_numpy_mtzints(dtype, hasna):
     """
-    Test DataSet.to_numpy() with int32-backed MTZDtypes
+    Test DataSet.to_numpy() with only int32-backed MTZDtypes
     """
     ds = rs.DataSet(
         {
             "X": np.random.randint(0, 100, size=100),
             "Y": np.random.randint(0, 100, size=100),
-        }
-    ).infer_mtz_dtypes()
+        },
+        dtype="MTZInt",
+    )
 
     if hasna:
         ds.loc[0, "X"] = np.nan
@@ -41,16 +42,17 @@ def test_to_numpy_ints(dtype, hasna):
 
 @pytest.mark.parametrize("dtype", [None, np.float32, np.float64, object])
 @pytest.mark.parametrize("hasna", [True, False])
-def test_to_numpy_floats(dtype, hasna):
+def test_to_numpy_mtzfloats(dtype, hasna):
     """
-    Test DataSet.to_numpy() with float32-backed MTZDtypes
+    Test DataSet.to_numpy() with only float32-backed MTZDtypes
     """
     ds = rs.DataSet(
         {
             "X": np.random.random(100),
             "Y": np.random.random(100),
-        }
-    ).infer_mtz_dtypes()
+        },
+        dtype="MTZReal",
+    )
 
     if hasna:
         ds.loc[0, "X"] = np.nan
@@ -66,7 +68,7 @@ def test_to_numpy_floats(dtype, hasna):
 
 @pytest.mark.parametrize("dtype", [None, np.float32, np.float64, object])
 @pytest.mark.parametrize("hasna", [True, False])
-def test_to_numpy_mtzdtypes(dtype, hasna):
+def test_to_numpy_mixed_mtzdtypes(dtype, hasna):
     """
     Test DataSet.to_numpy() with both int32-backed and float-32-backed MTZDtypes
     """
@@ -74,8 +76,10 @@ def test_to_numpy_mtzdtypes(dtype, hasna):
         {
             "X": np.random.random(100),
             "Y": np.random.randint(100),
-        }
-    ).infer_mtz_dtypes()
+        },
+    )
+    ds["X"] = ds["X"].astype("MTZReal")
+    ds["Y"] = ds["Y"].astype("MTZInt")
 
     if hasna:
         ds.loc[0, "X"] = np.nan
@@ -90,7 +94,7 @@ def test_to_numpy_mtzdtypes(dtype, hasna):
 
 
 @pytest.mark.parametrize("non_mtzdtype", ["string", np.int32, np.float32, bool, object])
-def test_to_numpy_object(non_mtzdtype):
+def test_to_numpy_non_mtzdtype(non_mtzdtype):
     """
     With a non-MTZDtype, DataSet.to_numpy() should always output the same thing as
     pandas.DataFrame.to_numpy(). Currently, that is "object".
@@ -99,8 +103,11 @@ def test_to_numpy_object(non_mtzdtype):
         {
             "X": np.random.random(100),
             "Y": np.random.randint(100),
-        }
-    ).infer_mtz_dtypes()
+        },
+    )
+    ds["X"] = ds["X"].astype("MTZReal")
+    ds["Y"] = ds["Y"].astype("MTZInt")
+
     ds["non_mtz"] = 0
     ds["non_mtz"] = ds["non_mtz"].astype(non_mtzdtype)
 

--- a/tests/dtypes/test_dataset_to_numpy.py
+++ b/tests/dtypes/test_dataset_to_numpy.py
@@ -93,7 +93,7 @@ def test_to_numpy_mtzdtypes(dtype, hasna):
 def test_to_numpy_object(non_mtzdtype):
     """
     With a non-MTZDtype, DataSet.to_numpy() should always output the same thing as
-    an pandas.DataFrame.to_numpy(). Currently, that is "object".
+    pandas.DataFrame.to_numpy(). Currently, that is "object".
     """
     ds = rs.DataSet(
         {


### PR DESCRIPTION
Pandas DataFrames that contain ExtensionDtypes always default to output data with `object` dtype when `DataFrame.to_numpy()` is called. This is suboptimal for MTZ data, which by construction must be compatible with `float32`, and possibly `int32`. 

This PR wraps the pandas call with `DataSet.to_numpy()` to assess whether a more sensible default (either `float32` or `int32`) can be used based on the existing data. This should help to avoid cases where data is unnecessarily cast to an `object` array, which can lead to unexpected behavior downstream.