### PR TITLE
Add return_edges argument to DataSet.assign_resolution_bins()

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -920,19 +920,14 @@ class DataSet(pd.DataFrame):
 
         if isinstance(bins, int):
             assignments, edges = bin_by_percentile(dHKL, bins=bins, ascending=False)
-            self.loc[:, "bin"] = DataSeries(assignments, dtype="I", index=self.index)
         else:
+            # Use bin edges for assignments and drop reflections outside of range
             mask = (dHKL >= min(bins)) & (dHKL <= max(bins))
             assignments = assign_with_binedges(dHKL[mask], bin_edges=bins)
             edges = np.array(bins)
+            self._update_inplace(self.loc[mask])
 
-            # Drop reflections outside of resolution range
-            result = self.loc[mask].copy()
-            result["bin"] = DataSeries(assignments, dtype="I", index=result.index)
-            if inplace:
-                self._update_inplace(result)
-            else:
-                self = result
+        self.loc[:, "bin"] = DataSeries(assignments, dtype="I", index=self.index)
 
         # Package return values
         result = [self]

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -879,7 +879,12 @@ class DataSet(pd.DataFrame):
 
     @inplace
     def assign_resolution_bins(
-        self, bins=20, inplace=False, return_labels=True, return_edges=False
+        self,
+        bins=20,
+        inplace=False,
+        return_labels=True,
+        format_str=".2f",
+        return_edges=False,
     ):
         """
         Assign reflections in DataSet to resolution bins.
@@ -893,8 +898,11 @@ class DataSet(pd.DataFrame):
         return_labels : bool
             Whether to return a list of labels corresponding to the edges
             of each resolution bin (default: True)
+        format_str : str
+            Format string for constructing bin labels
         return_edges : bool
-            Whether to return bin edges that define the resolution bin boundaries
+            Whether to return bin edges that define the resolution bin boundaries.
+            The bin edges are returned as a 1-dimensional array with `bins + 1` entries
             (default: False)
 
         Returns
@@ -903,12 +911,16 @@ class DataSet(pd.DataFrame):
         """
         dHKL = self.compute_dHKL()["dHKL"]
 
-        assignments, labels, edges = bin_by_percentile(dHKL, bins=bins, ascending=False)
+        assignments, edges = bin_by_percentile(dHKL, bins=bins, ascending=False)
         self["bin"] = DataSeries(assignments, dtype="I", index=self.index)
 
         # Package return values
         result = [self]
         if return_labels:
+            labels = [
+                f"{e1:{format_str}} - {e2:{format_str}}"
+                for e1, e2 in zip(edges[0:-1], edges[1:])
+            ]
             result.append(labels)
         if return_edges:
             result.append(edges)

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -890,6 +890,11 @@ class DataSet(pd.DataFrame):
         """
         Assign reflections in DataSet to resolution bins.
 
+        Notes
+        -----
+        - If bin edges are provided, any reflections outside of the specified range
+          are dropped.
+
         Parameters
         ----------
         bins : int, list, or np.ndarray
@@ -919,10 +924,15 @@ class DataSet(pd.DataFrame):
         else:
             mask = (dHKL >= min(bins)) & (dHKL <= max(bins))
             assignments = assign_with_binedges(dHKL[mask], bin_edges=bins)
-            result = self
-            result.loc[mask, "bin"] = assignments
+            edges = np.array(bins)
+
+            # Drop reflections outside of resolution range
+            result = self.loc[mask].copy()
+            result["bin"] = DataSeries(assignments, dtype="I", index=result.index)
             if inplace:
                 self._update_inplace(result)
+            else:
+                self = result
 
         # Package return values
         result = [self]

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -878,33 +878,44 @@ class DataSet(pd.DataFrame):
         return self
 
     @inplace
-    def assign_resolution_bins(self, bins=20, inplace=False, return_labels=True):
+    def assign_resolution_bins(
+        self, bins=20, inplace=False, return_labels=True, return_edges=False
+    ):
         """
         Assign reflections in DataSet to resolution bins.
 
         Parameters
         ----------
         bins : int
-            Number of bins
+            Number of bins (default: 20)
         inplace : bool
-            Whether to add the column in place or return a copy
+            Whether to add the column in place or return a copy (default: False)
         return_labels : bool
             Whether to return a list of labels corresponding to the edges
-            of each resolution bin
+            of each resolution bin (default: True)
+        return_edges : bool
+            Whether to return bin edges that define the resolution bin boundaries
+            (default: False)
 
         Returns
         -------
-        (DataSet, list) or DataSet
+        (DataSet, list, ndarray) or (DataSet, list) or DataSet
         """
         dHKL = self.compute_dHKL()["dHKL"]
 
-        assignments, labels = bin_by_percentile(dHKL, bins=bins, ascending=False)
+        assignments, labels, edges = bin_by_percentile(dHKL, bins=bins, ascending=False)
         self["bin"] = DataSeries(assignments, dtype="I", index=self.index)
 
+        # Package return values
+        result = [self]
         if return_labels:
-            return self, labels
-        else:
+            result.append(labels)
+        if return_edges:
+            result.append(edges)
+
+        if len(result) == 1:
             return self
+        return tuple(result)
 
     def stack_anomalous(
         self, plus_labels=None, minus_labels=None, suffixes=("(+)", "(-)")

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -907,7 +907,7 @@ class DataSet(pd.DataFrame):
 
         Returns
         -------
-        (DataSet, list, ndarray) or (DataSet, list) or DataSet
+        (DataSet, list), (DataSet, ndarray), (DataSet, list, ndarray) or DataSet
         """
         dHKL = self.compute_dHKL()["dHKL"]
 

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -919,7 +919,7 @@ class DataSet(pd.DataFrame):
         if return_labels:
             labels = [
                 f"{e1:{format_str}} - {e2:{format_str}}"
-                for e1, e2 in zip(edges[0:-1], edges[1:])
+                for e1, e2 in zip(edges[:-1], edges[1:])
             ]
             result.append(labels)
         if return_edges:

--- a/reciprocalspaceship/stats/completeness.py
+++ b/reciprocalspaceship/stats/completeness.py
@@ -91,9 +91,7 @@ def compute_completeness(
     if dmin:
         dataset = dataset.loc[dHKL >= dmin]
         dHKL = dHKL[dHKL > dmin]
-    assignments, labels, binedges = bin_by_percentile(
-        dHKL, bins=bins, ascending=False, return_edges=True
-    )
+    assignments, labels, binedges = bin_by_percentile(dHKL, bins=bins, ascending=False)
 
     # Adjust high resolution bin to dmin
     if dmin:

--- a/reciprocalspaceship/stats/completeness.py
+++ b/reciprocalspaceship/stats/completeness.py
@@ -91,7 +91,9 @@ def compute_completeness(
     if dmin:
         dataset = dataset.loc[dHKL >= dmin]
         dHKL = dHKL[dHKL > dmin]
-    assignments, labels, binedges = bin_by_percentile(dHKL, bins=bins, ascending=False)
+    assignments, binedges = bin_by_percentile(dHKL, bins=bins, ascending=False)
+
+    labels = [f"{e1:.2f} - {e2:.2f}" for e1, e2 in zip(binedges[0:-1], binedges[1:])]
 
     # Adjust high resolution bin to dmin
     if dmin:

--- a/reciprocalspaceship/stats/completeness.py
+++ b/reciprocalspaceship/stats/completeness.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 import reciprocalspaceship as rs
 from reciprocalspaceship.utils.asu import in_asu
-from reciprocalspaceship.utils.binning import assign_with_binedges, bin_by_percentile
+from reciprocalspaceship.utils.binning import assign_with_binedges
 from reciprocalspaceship.utils.stats import compute_redundancy
 
 
@@ -85,15 +85,17 @@ def compute_completeness(
         else:
             anomalous = True
 
-    # Get bin edges for resolution bins
+    # Apply resolution cutoff
     dHKL = dataset.compute_dHKL()["dHKL"]
     dmax = dHKL.max()
     if dmin:
         dataset = dataset.loc[dHKL >= dmin]
         dHKL = dHKL[dHKL > dmin]
-    assignments, binedges = bin_by_percentile(dHKL, bins=bins, ascending=False)
 
-    labels = [f"{e1:.2f} - {e2:.2f}" for e1, e2 in zip(binedges[0:-1], binedges[1:])]
+    # Assign resolution bins
+    dataset, labels, binedges = dataset.assign_resolution_bins(
+        bins=bins, return_labels=True, return_edges=True
+    )
 
     # Adjust high resolution bin to dmin
     if dmin:

--- a/reciprocalspaceship/stats/completeness.py
+++ b/reciprocalspaceship/stats/completeness.py
@@ -3,7 +3,6 @@ import pandas as pd
 
 import reciprocalspaceship as rs
 from reciprocalspaceship.utils.asu import in_asu
-from reciprocalspaceship.utils.binning import assign_with_binedges
 from reciprocalspaceship.utils.stats import compute_redundancy
 
 
@@ -135,11 +134,10 @@ def compute_completeness(
         cell=dataset.cell,
     )
     result.set_index(["H", "K", "L"], inplace=True)
-    dHKL = result.compute_dHKL()["dHKL"]
-    result = result.loc[dHKL < dmax]
-    dHKL = dHKL[dHKL < dmax]
-    assignments = assign_with_binedges(dHKL, binedges, right_inclusive=False)
-    result["bin"] = assignments
+    result = result.loc[result.compute_dHKL()["dHKL"] < dmax]
+    result.assign_resolution_bins(
+        binedges, inplace=True, return_labels=False, return_edges=False
+    )
     result["observed"] = result["n"] > 0
     asu = result.hkl_to_asu()
 

--- a/reciprocalspaceship/utils/binning.py
+++ b/reciprocalspaceship/utils/binning.py
@@ -58,7 +58,10 @@ def assign_with_binedges(data, bin_edges, right_inclusive=True):
 
 
 def bin_by_percentile(
-    data, bins=20, ascending=True, return_edges=False, format_str=".2f"
+    data,
+    bins=20,
+    ascending=True,
+    format_str=".2f",
 ):
     """
     Bin data by percentile.
@@ -71,8 +74,6 @@ def bin_by_percentile(
         Number of bins
     ascending : bool
         Whether to bin data by value from low to high
-    return_edges: bool
-        Whether to return the bin edges
     format_str : str
         Format string for constructing bin labels
 
@@ -80,10 +81,10 @@ def bin_by_percentile(
     ------
     assignments : np.ndarray
         Bins to which data were assigned
-    bin_labels : list
-        Labels denoting bin edges
-    bin_edges : np.ndarray (optional)
-        If `return_edges=True`, an array with the bin edges is returned
+    bin_labels : list of str
+        labels denoting bin edges
+    bin_edges : np.ndarray
+        Array with values of bin edges
     """
     if ascending:
         order = 1
@@ -101,7 +102,4 @@ def bin_by_percentile(
         for edge1, edge2 in zip(bin_edges[0:-1], bin_edges[1:])
     ]
 
-    if return_edges:
-        return assignments, bin_labels, bin_edges
-    else:
-        return assignments, bin_labels
+    return assignments, bin_labels, bin_edges

--- a/reciprocalspaceship/utils/binning.py
+++ b/reciprocalspaceship/utils/binning.py
@@ -61,7 +61,6 @@ def bin_by_percentile(
     data,
     bins=20,
     ascending=True,
-    format_str=".2f",
 ):
     """
     Bin data by percentile.
@@ -74,17 +73,13 @@ def bin_by_percentile(
         Number of bins
     ascending : bool
         Whether to bin data by value from low to high
-    format_str : str
-        Format string for constructing bin labels
 
     Return
     ------
     assignments : np.ndarray
         Bins to which data were assigned
-    bin_labels : list of str
-        labels denoting bin edges
     bin_edges : np.ndarray
-        Array with values of bin edges
+        Values of bin boundaries (1D array with `bins + 1` entries)
     """
     if ascending:
         order = 1
@@ -94,12 +89,6 @@ def bin_by_percentile(
         right = True
 
     bin_edges = np.percentile(data, np.linspace(0, 100, bins + 1)[::order])
-
     assignments = assign_with_binedges(data, bin_edges, right_inclusive=right)
 
-    bin_labels = [
-        f"{edge1:{format_str}} - {edge2:{format_str}}"
-        for edge1, edge2 in zip(bin_edges[0:-1], bin_edges[1:])
-    ]
-
-    return assignments, bin_labels, bin_edges
+    return assignments, bin_edges

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -420,15 +420,25 @@ def test_compute_multiplicity(dataset_hkl, inplace, include_centering, spacegrou
 @pytest.mark.parametrize("bins", [5, 10, 20, 50])
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("return_labels", [True, False])
-def test_assign_resolution_bins(data_fmodel, bins, inplace, return_labels):
+@pytest.mark.parametrize("return_edges", [True, False])
+def test_assign_resolution_bins(
+    data_fmodel, bins, inplace, return_labels, return_edges
+):
     """Test DataSet.assign_resolution_bins"""
 
     result = data_fmodel.assign_resolution_bins(
-        bins=bins, inplace=inplace, return_labels=return_labels
+        bins=bins,
+        inplace=inplace,
+        return_labels=return_labels,
+        return_edges=return_edges,
     )
 
-    if return_labels:
+    if return_labels and return_edges:
+        result, labels, edges = result
+    elif return_labels:
         result, labels = result
+    elif return_edges:
+        result, edges = result
 
     # Test bins
     assert "bin" in result.columns
@@ -444,6 +454,14 @@ def test_assign_resolution_bins(data_fmodel, bins, inplace, return_labels):
     # Test labels
     if return_labels:
         assert len(labels) == bins
+        assert isinstance(labels, list)
+        assert all([isinstance(l, str) for l in labels])
+
+    # Test edges
+    if return_edges:
+        assert len(edges) == bins + 1
+        assert np.all(np.diff(edges) < 0)
+        assert isinstance(edges, np.ndarray)
 
 
 @pytest.mark.parametrize("inplace", [True, False])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -417,53 +417,6 @@ def test_compute_multiplicity(dataset_hkl, inplace, include_centering, spacegrou
     assert isinstance(result["EPSILON"].dtype, rs.MTZIntDtype)
 
 
-@pytest.mark.parametrize("bins", [5, 10, 20, 50])
-@pytest.mark.parametrize("inplace", [True, False])
-@pytest.mark.parametrize("return_labels", [True, False])
-@pytest.mark.parametrize("return_edges", [True, False])
-def test_assign_resolution_bins(
-    data_fmodel, bins, inplace, return_labels, return_edges
-):
-    """Test DataSet.assign_resolution_bins"""
-
-    result = data_fmodel.assign_resolution_bins(
-        bins=bins,
-        inplace=inplace,
-        return_labels=return_labels,
-        return_edges=return_edges,
-    )
-
-    if return_labels and return_edges:
-        result, labels, edges = result
-    elif return_labels:
-        result, labels = result
-    elif return_edges:
-        result, edges = result
-
-    # Test bins
-    assert "bin" in result.columns
-    assert len(result["bin"].unique()) == bins
-    assert result.bin.max() == bins - 1
-
-    # Test inplace
-    if inplace:
-        assert id(result) == id(data_fmodel)
-    else:
-        assert id(result) != id(data_fmodel)
-
-    # Test labels
-    if return_labels:
-        assert len(labels) == bins
-        assert isinstance(labels, list)
-        assert all([isinstance(l, str) for l in labels])
-
-    # Test edges
-    if return_edges:
-        assert len(edges) == bins + 1
-        assert np.all(np.diff(edges) < 0)
-        assert isinstance(edges, np.ndarray)
-
-
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize(
     "op",

--- a/tests/test_dataset_binning.py
+++ b/tests/test_dataset_binning.py
@@ -93,19 +93,22 @@ def test_bindges_drops_reflections(data_fmodel, bins, inplace):
     Test DataSet.assign_resolution_bins() drops reflections outside of
     resolution range when provided explicit bin edges
     """
-
+    nrows = len(data_fmodel)
     result = data_fmodel.assign_resolution_bins(
         bins, inplace=inplace, return_labels=False, return_edges=False
     )
 
-    #    assert all(result["bin"] == 0)
+    assert all(result["bin"] == 0)
 
     dHKL = result.compute_dHKL()["dHKL"]
     assert all(dHKL <= max(bins))
     assert all(dHKL >= min(bins))
+    assert len(result) < nrows
 
     # Test inplace
     if inplace:
         assert id(result) == id(data_fmodel)
+        assert len(data_fmodel) == len(result)
     else:
         assert id(result) != id(data_fmodel)
+        assert len(data_fmodel) == nrows

--- a/tests/test_dataset_binning.py
+++ b/tests/test_dataset_binning.py
@@ -1,0 +1,127 @@
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("bins", [5, 10, 20, 50, [100.0, 1.0]])
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("return_labels", [True, False])
+@pytest.mark.parametrize("return_edges", [True, False])
+def test_assign_resolution_bins(
+    data_fmodel, bins, inplace, return_labels, return_edges
+):
+    """Test DataSet.assign_resolution_bins() arguments"""
+
+    result = data_fmodel.assign_resolution_bins(
+        bins=bins,
+        inplace=inplace,
+        return_labels=return_labels,
+        return_edges=return_edges,
+    )
+
+    if return_labels and return_edges:
+        result, labels, edges = result
+    elif return_labels:
+        result, labels = result
+    elif return_edges:
+        result, edges = result
+
+    # Test bins
+    assert "bin" in result.columns
+    if isinstance(bins, int):
+        assert len(result["bin"].unique()) == bins
+        assert result.bin.max() == bins - 1
+    else:
+        assert all(result["bin"].to_numpy() == 0)
+
+    # Test inplace
+    if inplace:
+        assert id(result) == id(data_fmodel)
+    else:
+        assert id(result) != id(data_fmodel)
+
+    # Test labels
+    if return_labels:
+        assert isinstance(labels, list)
+        assert all([isinstance(l, str) for l in labels])
+        if isinstance(bins, int):
+            assert len(labels) == bins
+        else:
+            assert len(labels) == len(bins) - 1
+
+    # Test edges
+    if return_edges:
+        assert np.all(np.diff(edges) < 0)
+        assert isinstance(edges, np.ndarray)
+        if isinstance(bins, int):
+            assert len(edges) == bins + 1
+        else:
+            assert all(edges == bins)
+
+
+@pytest.mark.parametrize("bins", [1, 5, 10, 20, 50])
+def test_binedges_equivalence(data_fmodel, bins):
+    """
+    Test DataSet.assign_resolution_bins() generates consistent assignment when
+    provided bin edges from `return_edges=True`
+    """
+
+    expected, edges = data_fmodel.assign_resolution_bins(
+        bins, return_labels=False, return_edges=True
+    )
+
+    result = data_fmodel.assign_resolution_bins(
+        edges, return_labels=False, return_edges=False
+    )
+
+    assert all(expected["bin"] == result["bin"])
+
+
+@pytest.mark.parametrize("reverse", [True, False])
+def test_binedges_order(data_fmodel, reverse):
+    """
+    Test DataSet.assign_resolution_bins() assignments depend on whether bin edges
+    are provided in ascending or descending order
+    """
+
+    expected, edges = data_fmodel.assign_resolution_bins(
+        2, return_labels=False, return_edges=True
+    )
+
+    # Flip bin edges -- all assignments should differ
+    if reverse:
+        result = data_fmodel.assign_resolution_bins(
+            edges[::-1], return_labels=False, return_edges=False
+        )
+        assert all(expected["bin"] != result["bin"])
+
+    # All assignments should be equivalent
+    else:
+        result = data_fmodel.assign_resolution_bins(
+            edges, return_labels=False, return_edges=False
+        )
+        assert all(expected["bin"] == result["bin"])
+
+
+@pytest.mark.parametrize("bins", [[8.0, 12.0], [12.0, 8.0], [12.0, 20.0]])
+@pytest.mark.parametrize("inplace", [True, False])
+def test_bindges_drops_reflections(data_fmodel, bins, inplace):
+    """
+    Test DataSet.assign_resolution_bins() drops reflections outside of
+    resolution range when provided explicit bin edges
+    """
+
+    result = data_fmodel.assign_resolution_bins(
+        bins, inplace=inplace, return_labels=False, return_edges=False
+    )
+
+    #    assert all(result["bin"] == 0)
+
+    dHKL = result.compute_dHKL()["dHKL"]
+    assert all(dHKL <= max(bins))
+    assert all(dHKL >= min(bins))
+
+    # Test inplace
+    if inplace:
+        assert id(result) == id(data_fmodel)
+    else:
+        assert id(result) != id(data_fmodel)

--- a/tests/test_dataset_binning.py
+++ b/tests/test_dataset_binning.py
@@ -58,41 +58,25 @@ def test_assign_resolution_bins(
             assert all(edges == bins)
 
 
-@pytest.mark.parametrize("bins", [1, 5, 10, 20, 50])
-def test_binedges_equivalence(data_fmodel, bins):
+@pytest.mark.parametrize("bins", [1, 2, 5, 10, 20, 50])
+@pytest.mark.parametrize("reverse", [True, False])
+def test_binedges_equivalence(data_fmodel, bins, reverse):
     """
     Test DataSet.assign_resolution_bins() generates consistent assignment when
-    provided bin edges from `return_edges=True`
+    provided bin edges from `return_edges=True`. Tests using bin edges provided
+    in both ascending or descending order
     """
 
     expected, edges = data_fmodel.assign_resolution_bins(
         bins, return_labels=False, return_edges=True
     )
 
-    result = data_fmodel.assign_resolution_bins(
-        edges, return_labels=False, return_edges=False
-    )
-
-    assert all(expected["bin"] == result["bin"])
-
-
-@pytest.mark.parametrize("reverse", [True, False])
-def test_binedges_order(data_fmodel, reverse):
-    """
-    Test DataSet.assign_resolution_bins() assignments depend on whether bin edges
-    are provided in ascending or descending order
-    """
-
-    expected, edges = data_fmodel.assign_resolution_bins(
-        2, return_labels=False, return_edges=True
-    )
-
-    # Flip bin edges -- all assignments should differ
+    # Reversed bin edges should reverse assignments
     if reverse:
         result = data_fmodel.assign_resolution_bins(
             edges[::-1], return_labels=False, return_edges=False
         )
-        assert all(expected["bin"] == (1 - result["bin"]))
+        assert all(expected["bin"] == ((bins - 1) - result["bin"]))
 
     # All assignments should be equivalent
     else:

--- a/tests/test_dataset_binning.py
+++ b/tests/test_dataset_binning.py
@@ -92,7 +92,7 @@ def test_binedges_order(data_fmodel, reverse):
         result = data_fmodel.assign_resolution_bins(
             edges[::-1], return_labels=False, return_edges=False
         )
-        assert all(expected["bin"] != result["bin"])
+        assert all(expected["bin"] == (1 - result["bin"]))
 
     # All assignments should be equivalent
     else:

--- a/tests/utils/test_binning.py
+++ b/tests/utils/test_binning.py
@@ -34,7 +34,7 @@ def test_assign_with_binedges_dataoutside(data, bin_edges, right_inclusive):
         np.repeat(np.linspace(0, 100, 1000), 3),  # Simulates unmerged data
     ],
 )
-@pytest.mark.parametrize("bins", [10, 20, 50])
+@pytest.mark.parametrize("bins", [1, 10, 20, 50])
 @pytest.mark.parametrize("ascending", [True, False])
 @pytest.mark.parametrize("shuffle", [True, False])
 def test_bin_by_percentile(data, bins, ascending, shuffle):
@@ -42,14 +42,17 @@ def test_bin_by_percentile(data, bins, ascending, shuffle):
     if shuffle:
         np.random.shuffle(data)
 
-    assignments, labels = rs.utils.bin_by_percentile(data, bins, ascending)
+    assignments, labels, edges = rs.utils.bin_by_percentile(data, bins, ascending)
 
     # Make sure number of bins is correct
     assert len(labels) == bins
+    assert len(edges) == bins + 1
     assert len(assignments) == len(data)
     assert len(np.unique(assignments)) == bins
 
-    if ascending:
+    if ascending and bins > 1:
         np.all(np.diff(assignments) >= 0)
-    else:
+        np.all(np.diff(edges) > 0)
+    elif bins > 1:
         np.all(np.diff(assignments) <= 0)
+        np.all(np.diff(edges) < 0)

--- a/tests/utils/test_binning.py
+++ b/tests/utils/test_binning.py
@@ -42,10 +42,9 @@ def test_bin_by_percentile(data, bins, ascending, shuffle):
     if shuffle:
         np.random.shuffle(data)
 
-    assignments, labels, edges = rs.utils.bin_by_percentile(data, bins, ascending)
+    assignments, edges = rs.utils.bin_by_percentile(data, bins, ascending)
 
     # Make sure number of bins is correct
-    assert len(labels) == bins
     assert len(edges) == bins + 1
     assert len(assignments) == len(data)
     assert len(np.unique(assignments)) == bins


### PR DESCRIPTION
Fixes #184 by adding a `return_edges` argument to `DataSet.assign_resolution_bins()`. This PR adds that flexibility to the API, but otherwise does not change the default behavior of the function to preserve backwards compatibility. 